### PR TITLE
Disallow /wiki/ in robots.txt

### DIFF
--- a/content/robots.txt
+++ b/content/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Disallow: /wiki/


### PR DESCRIPTION
Disallows search engines (and other crawlers) from indexing our wiki. Some users probably do not want our wiki to be the first result when their username is googled.