### PR TITLE
Fixed typo in contact page

### DIFF
--- a/content/about/contact.erb
+++ b/content/about/contact.erb
@@ -118,7 +118,7 @@ contact_links:
       <h1 class='title has-text-centered'>Slack info</h1>
       <div class='is-divider'></div>
       <p id='slack-info-text' class='is-size-5'>
-        You can register with any <strong>*.zeus.ugent.be</strong> or even <strong>*.ugent.be</strong> email address.
+        You can register with any <strong>*@zeus.ugent.be</strong> or even <strong>*@ugent.be</strong> email address.
         If you don't have one, try to reach us on one of our other channels and ask for an invitation.
       </p>
     </div>


### PR DESCRIPTION
Using @ugent.be instead of .ugent.be.