### PR TITLE
Fix cammie JQuery

### DIFF
--- a/content/cammie.erb
+++ b/content/cammie.erb
@@ -3,6 +3,7 @@ navigable: true
 title: Cammie
 ---
 <% content_for :scripts do %>
+<script src="https://code.jquery.com/jquery-3.0.0.min.js" charset="utf-8"></script>
 <%= asset :js, :cammie %>
 <%= asset :js, :message %>
 <% end %>


### PR DESCRIPTION
In https://github.com/ZeusWPI/zeus.ugent.be/commit/0c6307971ad5f424bab0bc25128e92dcb2738398, JQuery is no longer default enabled on all pages. Since Cammie needed JQuery, it broke and could no longer move.