### PR TITLE
update photon link to https://photon.komoot.io

### DIFF
--- a/layouts/partials/_map.erb
+++ b/layouts/partials/_map.erb
@@ -35,7 +35,7 @@ function performRequest(url, success_callback) {
     request.send();
 }
 
-performRequest("https://photon.komoot.de/api/?limit=1&q=<%= URI::encode_www_form_component(@location) %>", function(data) {
+performRequest("https://photon.komoot.io/api/?limit=1&q=<%= URI::encode_www_form_component(@location) %>", function(data) {
     var lat, lon;
 	if(data.features.length < 1) {
 		        lat = 51.0538286;


### PR DESCRIPTION
Explanation available on <https://photon.komoot.io>

>Note:
Until October 2020 the API was available under photon.komoot.de. Requests still work as they redirected to photon.komoot.io but please update your apps accordingly.