### PR TITLE
Add Katex (Math mode) support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,12 @@ gem 'nanoc'
 
 gem 'icalendar' # ical files
 gem 'kramdown'
+
+# Kramdown math mode gems
+gem 'kramdown-math-katex'
+# Also needed for autoprefixing
+gem 'mini_racer'
+
 gem 'sassc'
 gem 'typogruby'
 
@@ -24,8 +30,6 @@ group :development do
 end
 
 group :production do
-  # Faster css autoprefixing
-  gem 'mini_racer'
   # Autoprefixing for class
   gem 'autoprefixer-rails'
   gem 'htmlcompressor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,8 +53,13 @@ GEM
     ice_cube (0.16.3)
     json (2.5.1)
     json_schema (0.20.9)
+    katex (0.6.1)
+      execjs (~> 2.7)
     kramdown (2.3.0)
       rexml
+    kramdown-math-katex (1.0.1)
+      katex (~> 0.4)
+      kramdown (~> 2.0)
     libv8 (8.4.255.0)
     listen (3.4.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -161,6 +166,7 @@ DEPENDENCIES
   htmlcompressor
   icalendar
   kramdown
+  kramdown-math-katex
   mini_racer
   nanoc
   pandoc-ruby

--- a/Rules
+++ b/Rules
@@ -4,6 +4,7 @@
 require 'json'
 require 'icalendar'
 
+
 # Important!!!
 # First ignore the node_modules, we do not need any of it on the site directly.
 ignore '/node_modules/**/*'
@@ -103,7 +104,7 @@ end
 compile '/blog/*/*.md' do
   filter :erb
   layout '/blogpost.md'
-  filter :kramdown
+  filter :kramdown, {math_engine: :katex}
   filter :typogruby
 
   layout '/blogpost.erb'

--- a/layouts/blogpost.erb
+++ b/layouts/blogpost.erb
@@ -14,6 +14,9 @@
 
 <!-- Animate.css -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
+
+<!-- KaTeX math css -->
+<link rel="stylesheet" type="text/css" href="/assets/stylesheets/katex.css">
 <% end %>
 
 <div class="blog-heading">

--- a/lib/data_sources/katex.rb
+++ b/lib/data_sources/katex.rb
@@ -1,0 +1,17 @@
+require 'katex'
+
+class KatexDataSource < ::Nanoc::DataSource
+  identifier :katex
+
+  def items
+    katex_css_path = File.join(Katex.gem_path, 'vendor', 'katex', 'stylesheets', 'katex.css')
+
+    [
+      new_item(
+        File.open(katex_css_path).read,
+        {},
+        "/katex.css"
+      )
+    ]
+  end
+end

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -90,6 +90,9 @@ data_sources:
     items_root: /about/verslagen/
     content_dir: drive/verslagen/
     layouts_dir: null
+  -
+    type: katex
+    items_root: /assets/stylesheets
 
 # Configuration for the “check” command, which run unit tests on the site.
 checks:


### PR DESCRIPTION
This PR adds support for math symbols, which is something I hope to use in the future on the Zeus site. Cool thing about Katex is that it renders the math symbols server side, only needing a bit of css. Unlike Mathjax, no javascript is required.

<img width="1437" alt="Screenshot 2021-02-26 at 15 22 38" src="https://user-images.githubusercontent.com/3852492/109312028-d2866900-7846-11eb-96d5-9934dae8d160.png">
