### PR TITLE
reduce size of titles and text when mobile, fixes #286

### DIFF
--- a/layouts/partials/_events_tile.erb
+++ b/layouts/partials/_events_tile.erb
@@ -12,17 +12,17 @@
   <img class="event-tile-image" src="<%= @event[:image] %>" alt="">
   <% end %>
     <div class="event-text">
-      <h2 class="has-text-centered">
+      <h2 class="is-size-5-mobile has-text-centered">
         <%= @event[:title] %>
       </h2>
 
-      <div class="description has-text-centered">
+      <div class="is-size-6-mobile description has-text-centered">
         <%= @event[:description] %>
       </div>
 
       <div class="is-divider"></div>
 
-      <div class="event-time-loc">
+      <div class="is-size-7-mobile  event-time-loc">
         <%= fa :'clock-o' , fw: true %><%= @event[:time].strftime('%A %d %B, %H:%M') %>
         <br>
         <%= fa :'map-marker', fw: true %><%= @event[:location] %>


### PR DESCRIPTION
See #286 for screenshot of previous issue.

![image](https://user-images.githubusercontent.com/3852492/109637061-9441c000-7b4c-11eb-9ecf-0aa3ee4c1bb2.png)
