### PR TITLE
Fix KaTeX (math mode) fonts

### DIFF
--- a/Rules
+++ b/Rules
@@ -3,6 +3,8 @@
 
 require 'json'
 require 'icalendar'
+require 'kramdown'
+require 'kramdown-math-katex'
 
 
 # Important!!!

--- a/content/assets/stylesheets/includes/general.scss
+++ b/content/assets/stylesheets/includes/general.scss
@@ -15,7 +15,6 @@ pre .line-numbers {
   transition: all .15s ease;
 
   box-shadow: 0 4px 6px rgba(50,50,93,.11), 0 1px 3px rgba(0,0,0,.08);
-
 }
 
 a.box:hover {

--- a/lib/data_sources/katex.rb
+++ b/lib/data_sources/katex.rb
@@ -5,13 +5,12 @@ class KatexDataSource < ::Nanoc::DataSource
 
   def items
     katex_css_path = File.join(Katex.gem_path, 'vendor', 'katex', 'stylesheets', 'katex.css')
+    katex_font_paths = Dir[File.join(Katex.gem_path, 'vendor', 'katex', 'fonts', '*')]
 
-    [
-      new_item(
-        File.open(katex_css_path).read,
-        {},
-        "/katex.css"
-      )
-    ]
+    font_items = katex_font_paths.map do |e|
+      font_name = File.split(e)[-1]
+      new_item(File.open(e).read, {}, "/fonts/#{font_name}")
+    end
+    [new_item(File.open(katex_css_path).read, {}, "/katex.css")] + font_items
   end
 end


### PR DESCRIPTION
Forgot adding some fonts for the math mode I added earlier. It looks a lot nicer now!

<img width="881" alt="Screenshot 2021-03-18 at 22 18 17" src="https://user-images.githubusercontent.com/3852492/111699068-ee729e80-8837-11eb-9559-71ef9d850c6a.png">
