### PR TITLE
Vul archieven aan

### DIFF
--- a/content/blog/00-01/bot.md
+++ b/content/blog/00-01/bot.md
@@ -1,0 +1,9 @@
+---
+title: Java-bot project.
+created_at: 29-03-2001
+---
+
+Alle leden en geinteresseerden mogen meewerken aan het in Java programmeren van een irc-bot. Mail junk@zeus.rug.ac.be".
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/00-01/linux-lessen-online.md
+++ b/content/blog/00-01/linux-lessen-online.md
@@ -1,0 +1,9 @@
+---
+title: Linuxlessen online.
+created_at: 03-12-2000
+---
+
+De lessen kunnen nu ook [gedownload](http://web.archive.org/web/20010303211508/http://www.zeus.rug.ac.be/linuxles.shtml#download) worden.
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/00-01/linux.md
+++ b/content/blog/00-01/linux.md
@@ -1,0 +1,8 @@
+---
+title: Data Linuxlessen gekend!
+created_at: 01-12-2000
+---
+
+Zeus WPI geeft terug Linuxlessen! Er zijn dit keer 4 lessen voorzien, met onder meer Linux-installatie en configuratie voor de beginnende gebruiker. Voor de gevorderde gebruiker hebben we enkele uiteenzettingen over firewalling, routing, samba, ... Om je in te schrijven volstaat een mailtje naar lessen@zeus.rug.ac.be met een vermelding van je naam, de les en het aantal aanwezige personen! Voor meer informatie ga je naar de [lessenpagina](http://web.archive.org/web/20001208193800/http://www.zeus.rug.ac.be:80/pub.shtml).
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/00-01/meer-lessen.md
+++ b/content/blog/00-01/meer-lessen.md
@@ -1,0 +1,9 @@
+---
+title: Nieuwe lessen in het verschiet.
+created_at: 01-03-2001
+---
+
+Er worden terug lessen gegeven. Deze keer gaan ze over PHP, firewalling, ... Meer info volgt binnenkort.
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/00-01/mirrors.md
+++ b/content/blog/00-01/mirrors.md
@@ -1,0 +1,9 @@
+---
+title: Mirrors bijgewerkt tijdens de vakantie
+created_at: 01-10-2000 10:00
+---
+
+De mirrors van Zeus WPI (ftp.zeus.rug.ac.be) werden in de vakantie goed onderhouden, en verschillende nieuwe zaken werden toegevoegd of ge-updated. Zo hebben we ondermeer Debian 2.2 staan en Tucows met de nieuwe layout. We proberen altijd de recenste versies van alles te vinden. Indien iets ontbreekt aarzel dan zeker niet om ons te contacteren, zodat we onze diensten altijd kunnen uitbreiden naar de wensen van onze gebruikers.
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/00-01/php-lessen.md
+++ b/content/blog/00-01/php-lessen.md
@@ -1,0 +1,22 @@
+---
+title: ZEUS WPI geeft PHP lessen.
+created_at: 30-03-2001
+---
+
+Op 18, 25 april en 2, 9 mei geven we PHP lessen. Een niet te missen kans voor alle webmasters onder jullie. Meer info volgt binnenkort.
+
+
+De Linux lessen kunnen nu ook [gedownload](http://web.archive.org/web/20010331094024/http://www.zeus.rug.ac.be:80/lessen/linuxles.shtml#download) worden.
+
+_Update 01/05/2001_
+
+Op 18, 25 april en 2, 9 mei geven we PHP lessen. Een niet te missen kans voor alle webmasters onder jullie. De lessenreeks is nu reeds halfweg. De teksten en de voorbeelden zijn beschikbaar via onderstaande link.
+
+[Meer info, de teksten en de voorbeelden...](http://web.archive.org/web/20010429044958/http://www.zeus.rug.ac.be/lessen/phples.shtml)
+
+_Update 19/05/2001_
+
+De lessen van 2000-2001 zijn achter de rug. De lessenreeks over PHP oogste veel bijval. De lessen werden toegelicht met programmavoorbeelden en uitvoerige lesnota's. Je kan de lesnota's en de source-codes van de voorbeelden afhalen van de zeus-site.
+[Meer info, de teksten en de voorbeelden...](http://web.archive.org/web/20010519194513/http://www.zeus.rug.ac.be:80/lessen/phples.shtml)
+
+_Noot van de archivaris: de datum van deze blogpost en zijn updates is een schatting._

--- a/content/blog/00-01/security.md
+++ b/content/blog/00-01/security.md
@@ -1,0 +1,10 @@
+---
+title: "ZEUS WPI's security pagina."
+created_at: 31-03-2001
+---
+
+Er is gebleken dat er een grote nood is aan enkele webpagina's met uitleg over het hoe en waarom van security (of beveiliging voor de fanatiekelingen onder u). Vooral het hoe bleek een probleem te zijn.
+
+Op de [security pagina](http://web.archive.org/web/20010331094024/http://www.zeus.rug.ac.be/security/) vindt u meer uitleg.
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/00-01/site.md
+++ b/content/blog/00-01/site.md
@@ -1,0 +1,8 @@
+---
+title: Nieuwe site Zeus WPI
+created_at: 02-10-2000
+---
+
+Vanaf vandaag is de nieuwe site van Zeus WPI online. De layout is grondig veranderd, maar de inhoud is ongeveer gelijk gebleven (alles wat er vroeger was is nu ook nog terug te vinden), en enkele nieuwe zaken werden toegevoegd. Dit is een eerste stap in de richting waarin we dit jaar willen gaan. We kiezen voor vernieuwing, en naar aanleiding van het 10-jarig bestaan van Zeus zullen nog andere dingen volgen. Hou ons in de gaten!
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/00-01/tshirt.md
+++ b/content/blog/00-01/tshirt.md
@@ -1,0 +1,9 @@
+---
+title: De Zeus t-shirts.
+created_at: 02-12-2000
+---
+
+Ben jij een grafisch genie? Kun je overweg met een tekenpakket? Voel je je geroepen om het Zeus t-shirt te ontwerpen? Aarzel dan niet en ontwerp voor ons een t-shirt met het gekende [Zeus-logo](http://www.zeus.rug.ac.be/logos/logozeus.jpg). Ontwerpen kun je mailen naar ons [keurteam](mailto:tshirts@zeus.rug.ac.be). Na overleg met het bestuur wordt de mooiste/origineelste uit gekozen.
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/00-01/verjaardag.md
+++ b/content/blog/00-01/verjaardag.md
@@ -1,0 +1,10 @@
+---
+title: Foto's van de verjaardag online!
+created_at: 11-05-2001
+---
+
+Op 23 april vierde Zeus zijn 10-jarig bestaan met een korte receptie en een lange after-party in de BoomBoom. De foto's zijn te bezichtigen op onze site. Jammer genoeg zijn deze niet beschikbaar van buiten het RUGnet.
+
+[Meer foto's...](http://web.archive.org/web/20031009082128/http://zeus.rug.ac.be/~jonas/)
+
+_Noot van de archivaris: de datum van deze blogpost en zijn updates is een schatting._

--- a/content/blog/01-02/bedankt.md
+++ b/content/blog/01-02/bedankt.md
@@ -1,0 +1,13 @@
+---
+title: Zeus dankt de lesgevers van de installatieles...
+created_at: 28-11-2001
+---
+
+Hierbij willen we Bernard Grymonpon, Frank Louwers en Rudy Gevaert danken voor hun inzet voor de [installatieles](http://web.archive.org/web/20020802193359/http://www.zeus.rug.ac.be:80/pub.shtml). Alsook danken we de talrijke aanwezigen.
+
+Als ook willen we onze verontschuldigingen aanbieden aan de aanwezigen, voor de ietwat hectische les. Dit kwam omdat Bernard de dag zelf past wist dat hij de les ging geven. Tom die de les normaal ging geven was geveld door de griep.
+
+Na de les hebben we de X-server ook aan de praat gekregen (wat tijdens de les niet lukte), we gebruikten een verkeerde driver. Maw inspecteer uw hardware voor je begint te installeren.
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/01-02/blok.md
+++ b/content/blog/01-02/blok.md
@@ -1,0 +1,9 @@
+---
+title: Blok
+created_at: 26-05-2002
+---
+
+De examens staan voor de deur, dus dit academiejaar houden we het, wat de lessen betreft, voor bekeken.
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/01-02/latex.md
+++ b/content/blog/01-02/latex.md
@@ -1,0 +1,14 @@
+---
+title: Latex les !
+created_at: 01-03-2002
+---
+
+LaTeX is een taal waarmee men gemakkelijk documenten van hoge kwaliteit kan produceren. De kwaliteit slaat vooral op: het invoegen van wiskundige tekst op eenvoudige manier in een document, het maken van thesissen, het opstellen van brieven.
+
+Kortom LaTeX is het vervangmiddel voor tekstverwerkingprogramma's als Word die doen wat je niet wilt, LaTex doet wat jij wilt.
+
+De lessen gaan door op donderdag 07/03 en dinsdag 12/03, telkens op 18h30 in auditorium A0 in gebouw S9 van de campus Sterre.
+Een gratis cursus tijdens de les ? Stuur een mailtje naar lessen@zeus.rug.ac.be.
+
+
+_Noot van de archivaris: de aanmaakdatum van dit evenement is een schatting._

--- a/content/blog/01-02/leden.md
+++ b/content/blog/01-02/leden.md
@@ -1,0 +1,9 @@
+---
+title: ZEUS WPI zoekt nieuwe leden
+created_at: 01-10-2001
+---
+
+Ben je een nieuwe student, heb je interesse in de informatica? Word dan [lid](http://web.archive.org/web/20011127170659/http://www.zeus.rug.ac.be:80/newlid.shtml) van Zeus.
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/01-02/les.md
+++ b/content/blog/01-02/les.md
@@ -1,0 +1,9 @@
+---
+title: Zeus geeft linuxles.
+created_at: 27-11-2001
+---
+
+Op dinsdag 20/11 en 27/11 geven we terug Linuxles. Meer info op de [lessen](http://web.archive.org/web/20020802193359/http://www.zeus.rug.ac.be:80/pub.shtml)pagina.
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/01-02/php-lessen.md
+++ b/content/blog/01-02/php-lessen.md
@@ -1,0 +1,9 @@
+---
+title: ZEUS WPI geeft PHP lessen
+created_at: 13-03-2001
+---
+
+Op 15,18,22 en 25 april geeft ZeusWPI een lessenreeks over PHP.
+
+
+_Noot van de archivaris: de datum van deze blogpost en zijn updates is een schatting._

--- a/content/blog/02-03/c-lessen.md
+++ b/content/blog/02-03/c-lessen.md
@@ -1,0 +1,8 @@
+---
+title: Onze lang verwachte C-lessen
+created_at: 10-02-2003
+---
+
+Vanaf woensdag 19/2 begint Geert Vernaeve aan zijn legendarische C-cursus. 4 inleidingslessen leiden je in in de wondere wereld van programmeren in C. Heb je altijd al willen helpen aan een van die Open Source (sorry.. Vrije) projecten, of wil je verder kijken dan je java-neus lang is, schrijf je dan in op lessen at zeus.ugent.be . Als je een gedrukte cursus wenst (meer info [hier](http://web.archive.org/web/20030321012833/http://www.zeus.rug.ac.be:80/c.shtml)), vergeet dat ook niet te vermelden in je mailtje.
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/externe-bereikbaarheid.md
+++ b/content/blog/02-03/externe-bereikbaarheid.md
@@ -1,0 +1,24 @@
+---
+title: Externe bereikbaarheid
+created_at: 08-07-2003
+author: Olivier Verhoogen
+---
+
+Hallo!
+
+Zoals sommigen onder jullie wel al gehoord, gemerkt en/of op
+bovennatuurlijke wijze aangevoeld hebben is Zeus vanaf heden ook van
+buiten (R)UGnet bereikbaar. We gaan bovendien tijdens de zomermaanden
+(hoezo 2e zit?) serieus aan onze setup sleutelen zodat we het komende
+academiejaar kunnen starten zoals het een werkgroep informatica betaamt.
+Het is uit veiligheidsoverwegingen voorlopig wel niet mogelijk nieuwe
+connecties van op een zeus-machine naar buiten te starten.
+Het zal nog even wachten zijn op koele dingen als CVS respositories, MySQL
+databases en dergelijke meer. Het is ondertussen wel weer mogelijk om op
+de conventionele manier PHP te gebruiken.
+
+Enjoy!
+
+
+Het admin team,
+Het bestuur.

--- a/content/blog/02-03/freebsd.md
+++ b/content/blog/02-03/freebsd.md
@@ -1,0 +1,9 @@
+---
+title: FreeBSD cvsup mirror
+created_at: 02-02-2003
+author: Kenneth
+---
+
+Op hermes.rug.ac.be is nu tevens een cvsup mirror te vinden van FreeBSD. Mensen die FreeBSD gebruiken kunnen hun sources dus syncen via hermes.rug.ac.be; via ftp zijn tevens de packages te vinden. Je kunt die dus beter via hermes downloaden ipv de mastersites nog extra te belasten.
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/hardware.md
+++ b/content/blog/02-03/hardware.md
@@ -1,0 +1,8 @@
+---
+title: Nieuw hardwareproject
+created_at: 23-11-2002
+---
+
+Een netwerkje van oude computers ineenknutselen.
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/kernel.md
+++ b/content/blog/02-03/kernel.md
@@ -1,0 +1,9 @@
+---
+title: Kernel-les
+created_at: 15-03-2003
+---
+
+Download [hier](http://web.archive.org/web/20030528113017/http://www.zeus.rug.ac.be:80/kernel_introductie.pdf) de les over de linux-kernel, gegeven door Bart De Schuymer.
+Meer info op zijn [project-page](http://web.archive.org/web/20030801141805/http://zeus.rug.ac.be/~bdschuym/) (RUGnet intern).
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/listserver.md
+++ b/content/blog/02-03/listserver.md
@@ -1,0 +1,8 @@
+---
+title: Listserver
+created_at: 22-11-2002
+---
+
+Ja die werkt terug!
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/mailinglijsten.md
+++ b/content/blog/02-03/mailinglijsten.md
@@ -1,0 +1,9 @@
+---
+title: Interessante mailinglists
+created_at: 20-03-2003
+---
+
+Onlangs werden bij Zeus twee nieuwe mailinglists opgericht, nl. help@zeus.rug.ac.be en announce@zeus.rug.ac.be. Hoe u kan inschrijven leest u [hier](http://web.archive.org/web/20030502094002/http://www.zeus.rug.ac.be/mailinglists.shtml).
+
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/mirror.md
+++ b/content/blog/02-03/mirror.md
@@ -1,0 +1,8 @@
+---
+title: Zeus Mirror
+created_at: 21-11-2002
+---
+
+Onze mirror is nu ook bereikbaar via rsync.
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/oreilly.md
+++ b/content/blog/02-03/oreilly.md
@@ -1,0 +1,8 @@
+---
+title: O'reilly reviews
+created_at: 24-11-2002
+---
+
+O'reilly heeft ons een tijdje terug 4 boeken opgestuurd om te [reviewen](http://web.archive.org/web/20021124131950/http://www.zeus.rug.ac.be:80/reviews/). Dit is nu gebeurd. Bedankt aan O'reilly en de reviewers.
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/projecten.md
+++ b/content/blog/02-03/projecten.md
@@ -1,0 +1,8 @@
+---
+title: Zeus Projecten Pagina
+created_at: 20-11-2002
+---
+
+De zeus projecten pagina is geactualiseerd naar 2002-2003, zie [Projecten](http://web.archive.org/web/20021207222624/http://www.zeus.rug.ac.be/projects.shtml).
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/rugnet.md
+++ b/content/blog/02-03/rugnet.md
@@ -1,0 +1,8 @@
+---
+title: Overleven op RUGnet
+created_at: 30-09-2002
+---
+
+"Overleven op RUGnet" is nu ook [on-line](http://web.archive.org/web/20021004042945/http://www.zeus.rug.ac.be/overleven/) te raadplegen!
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/02-03/voyeur.md
+++ b/content/blog/02-03/voyeur.md
@@ -1,0 +1,10 @@
+---
+title: Zeus en voyeurisme
+created_at: 17-03-2003
+---
+
+Is er momenteel iemand in de Zeuskelder? Ga ik er niet voor een gesloten deur staan? Zit je ook soms met die prangende vragen, vooraleer je naar de kelder komt, dan bestaat daar nu een handige oplossing voor. Er hangt nl. een webcam in de kelder, die om de paar seconden een beeldje doorstuurt, waarop je kan ziet wat er bij Zeus momenteel aan de hand is. De beelden kan je bekijken op [NaN's homepagina](http://www.zeus.rug.ac.be/~kris/zeus.jpg) (RUGnet intern).
+
+En aan iedereen die van plan is de Zeuskelder leeg te komen halen: We're watching you!
+
+_Noot van de archivaris: de datum van deze blogpost is een schatting._

--- a/content/blog/03-04/gelukwensen.md
+++ b/content/blog/03-04/gelukwensen.md
@@ -1,0 +1,8 @@
+---
+title: Generieke gelukwensen
+created_at: 24-12-2003
+author: Olivier Verhoogen
+---
+
+Ik zou namens het bestuur en de admin alle leden (en de toevallige meekijkers ook wel) een vrolijk kerstfeest en een gelukkig nieuwjaar willen toewensen. Of vertaald naar de minder gelukkigen onder ons: een voorspoedige blok en een geslaagde eerste examenperiode!
+

--- a/content/blog/03-04/latex.md
+++ b/content/blog/03-04/latex.md
@@ -1,0 +1,9 @@
+---
+title: LaTeX-lessen
+created_at: 15-10-2003
+author: Kenneth
+---
+
+Op maandag 27 oktober en maandag 3 november om 18u, geeft Gaspard 2 lessen over LaTeX. Dus als je meer wil weten over deze professionele typesetting-language, kom dan zeker af naar auditorium A0, S9, Campus De Sterre. Stuur vooraf wel even een mailtje naar lessen@zeus.UGent.be, met de vermelding of je een gedrukte cursus wil. Tot dan.
+
+Update: De nieuwe cursus staat nu ook online. Je kan hem vinden onder publicaties.

--- a/content/blog/03-04/les-2.md
+++ b/content/blog/03-04/les-2.md
@@ -1,0 +1,9 @@
+---
+title: PHP lessen
+created_at: 01-04-2004
+author: Rudy Gevaert
+---
+
+Zeus geeft nog es les.
+
+De vier eerste maandagen na de paasvakantie, dat zijn 19 en 26 april en 3 en 10 mei, geeft Simkin 4 PHP-lessen, telkens om 18.00u. Wil je komen stuur dan een mailtje naar lessen @ zeus . ugent . be.

--- a/content/blog/03-04/les.md
+++ b/content/blog/03-04/les.md
@@ -1,0 +1,9 @@
+---
+title: Les, les en nog eens les
+created_at: 07-03-2004
+author: Kenneth
+---
+
+Op 18 maart om 19.00 geeft Mattias Campe een introductie tot het IM-protocol **Jabber**.
+In samenwerking met de Werkgroep Vrije Software van het VTK gaat er nog een les door over **Mandrake** op 22 maart, een **GNU/Linux**-introductieles op 25 maart, en een **LaTeX**-les op 22 april.
+De vier eerste maandagen na de paasvakantie tenslotte, dat zijn 19 en 26 april en 3 en 10 mei, geeft Simkin 4 **PHP**-lessen, telkens om 18.00u.

--- a/content/blog/03-04/ontgroend.md
+++ b/content/blog/03-04/ontgroend.md
@@ -1,0 +1,11 @@
+---
+title: Gent OntgroenD
+created_at: 08-10-2003
+author: Olivier Verhoogen
+---
+
+Op dit eigenste moment gaat er in zaal Kunstzicht in resto Overpoort een mega verenigingenshowofftoestand door. Natuurlijk is ook Zeus WPI vertegenwoordigd! Voor die arme mensen die hier al de fun moeten missen hebben we rap een webcampaginaatje in elkaar gefoefeld.
+
+In zoverre Lieven zijn macje het niet nog eens begeeft kan je live meevolgen op ons [kassa IP](http://overes15.ugent.be/). NaN heeft ook een paar snapshots genomen met de digicam van zijn nonkel. Die zijn te bezichtigen op zijn (nieuwe) [site](http://web.archive.org/web/20031128075228/http://www.zeus.ugent.be/~kris/gallery/view_album.php?set_albumName=gentontgroend&page=1).
+
+UPDATE (1650CEST): Het vat is af... dus we zijn voort.

--- a/content/blog/03-04/tshirt.md
+++ b/content/blog/03-04/tshirt.md
@@ -1,0 +1,25 @@
+---
+title: Zeus T-shirts!
+created_at: 01-09-2003
+author: Olivier Verhoogen
+---
+
+Weledelgeboren leden van de Werkgroep Publieke Informatica,
+
+Na veel (en af en toe ook wel wat minder) geduld staat het er eindelijk
+toch van te komen: er worden opnieuw Zeus T-Shirts gedrukt!
+
+Origineel als we zijn kiezen we voor een zwart shirt met langs voor een
+klein Zeus logo en langs achter de reeds welbekende adminspotting tekst
+(zo niet: zie www.adminspotting.org). De om en bij volledige gelijkenis
+met de vorige editie shirts berust hierbij uiteraard geheel op toeval.
+
+Zie je het wel zitten om je kleerkast aan te vullen met een (of meerdere)
+shirts van je favoriete werkgroep? Schrijf dan snel per gewenst exemplaar
+8 euro over op rekeningnummer 979-9937065-02. Vermeld in de mededeling
+duidelijk je loginnaam, het gewenste aantal shirts alsook de gewenste
+maten (M, L of XL).
+
+Ik plaats de bestelling in de week van 22 september dus zie dat je
+overschrijving uiterlijk tegen dan is voltrokken. Met een beetje geluk
+krijg je dan je eigenste exempla(a)r(en) al op de eerste ledenvergadering.

--- a/content/blog/03-04/update.md
+++ b/content/blog/03-04/update.md
@@ -1,0 +1,10 @@
+---
+title: Updates
+created_at: 16-02-2004
+author: Kenneth
+---
+
+Een nieuw semester, nieuwe gewoontes. De nieuwe openingstijden van de kelder vind je onder Kelderpermanenties.
+Ook zijn er nieuwe versies beschikbaar van onze XHTML/CSS en LaTeX-lessen. Nog steeds te vinden onder Publicaties.
+
+

--- a/content/blog/03-04/webcam.md
+++ b/content/blog/03-04/webcam.md
@@ -1,0 +1,8 @@
+---
+title: Webcam online
+created_at: 30-10-2003
+author: Kenneth
+---
+
+De webcam is terug online! Ons nerdzijn is hier te bewonderen. Het is de bedoeling de boel volledig streaming te maken als project.
+

--- a/content/blog/03-04/website-update.md
+++ b/content/blog/03-04/website-update.md
@@ -1,0 +1,11 @@
+---
+title: Website Update
+created_at: 19-04-2004
+author: Kenneth
+---
+
+De site onderging een kleine update. Enkele van de wijzigingen:
+
+- er is een nieuwe categorie toegevoegd: in het fotoboek kunt u foto's bekijken van voorbije Zeus-activiteiten
+- bij publicaties kunt u nu ook de cursus over de Linux kernel downloaden
+- de verslagen zijn up-to-date gebracht

--- a/content/blog/03-04/xhtml.md
+++ b/content/blog/03-04/xhtml.md
@@ -1,0 +1,9 @@
+---
+title: lessen XHTML / CSS
+created_at: 08-11-2003
+author: Kenneth
+---
+
+Op woensdag 3 en 10 **en 16** december organiseert Zeus lessen over XHTML en CSS. Kijk snel op de [lessenpagina](http://web.archive.org/web/20031124172524/http://zeus.rug.ac.be:80/index.php?include=lessen).
+
+

--- a/content/blog/04-05/lessen.md
+++ b/content/blog/04-05/lessen.md
@@ -1,0 +1,15 @@
+---
+title: C-lessenreeks & Linux kernel les
+created_at: 15-03-2005
+author: Lieven
+---
+
+Programmeurs en aspirant-programmeurs opgelet!
+
+Op **21 en 23 maart** en op **11 april** leert gnorkende guru Geert Vernaeve ons in drie keer het fijne van de **programmeertaal C**. Om daarna onze kunde eens aan de praktijk te toetsen vertelt Bart De Schuymer ons op **13 april** wat meer over de binnenkant van de **linux kernel**.
+
+We beginnen telkens om **19u00 in auditorium A0**. Dat is als vanouds op campus De Sterre in gebouw S9 op het gelijkvloers.
+
+Beide lesgevers voorzien een **begeleidende cursus**. Wil je een gedrukt exemplaar? Mail dan op voorhand even naar clessenreeks at zeus.ugent.be . Je kopie ligt dan klaar bij het begin van de eerste les. De kostprijs zal hoogstens de drukkosten evenaren.
+
+[klik hier om de affiche in PDF-formaat te downloaden](http://web.archive.org/web/20050513102651/http://www.zeus.ugent.be/~simkin/affiches/affiche-c.pdf)

--- a/content/blog/04-05/patenten.md
+++ b/content/blog/04-05/patenten.md
@@ -1,0 +1,11 @@
+---
+title: Studenten Tegen Softwarepatenten
+created_at: 21-05-2005
+author: Wim De Smet
+---
+
+Volgende week woensdag (25 mei) vindt er een algemene actie plaats tegen softwarepatenten, georganiseerd door studenten van de verschillende universiteiten. Bij zeus steunen we dit natuurlijk van harte.
+
+
+Voor zij die geinteresseerd zijn in iets te doen op die dag, kijk voor meer info op:<br>
+[http://wiki.vrijschrift.org/StudentenTegenSoftwarePatenten](http://web.archive.org/web/20050830053612/http://wiki.vrijschrift.org/StudentenTegenSoftwarePatenten)

--- a/content/blog/05-06/activiteiten.md
+++ b/content/blog/05-06/activiteiten.md
@@ -1,0 +1,9 @@
+---
+title: "Activiteiten deze week: poolen en les debian Package Management"
+created_at: 07-03-2006
+author: Wim De Smet
+---
+
+Dinsdag 07/03 gaan de leden van Zeus poolen. Hierbij een kleine herinnering aan de ingeschreven leden om vanavond aanwezig te zijn aan de Stars and Stripes.
+
+Verder komt woensdag 08/03 Luk Claes ons wat uitleg doen over packages in Debian: hoe zitten ze in elkaar, hoe maak je ze zelf, vragensessie, ... De les gaat door in Auditorium A0 in de Sterre S9 om 19:30. Be there.

--- a/content/blog/05-06/onderhoud.md
+++ b/content/blog/05-06/onderhoud.md
@@ -1,0 +1,7 @@
+---
+title: Onderhoud servers Zeus
+created_at: 16-05-2006
+author: Wim De Smet
+---
+
+De servers van Zeus zullen di 16 mei tussen 18:00 en 23:00 in onderhoud zijn dus er zal slechts beperkte functionaliteit zijn tijdens deze periode.

--- a/content/blog/05-06/projecten.md
+++ b/content/blog/05-06/projecten.md
@@ -1,0 +1,11 @@
+---
+title: Details nieuwe softwareprojecten zeus
+created_at: 28-10-2005
+author: Wim De Smet
+---
+
+Programmeurs en aspirant-programmeurs opgelet!
+
+Zoals op de ledenvergadering besloten (het verslag komt er hopelijk binnenkort aan) zullen enkele gezamenlijke projecten onder zeusleden gelanceerd worden. Momenteel is er nog geen streepje code en enkel een nieuwe mailinglist: projecten AT zeus dot ugent.be. [Schrijf je in](https://lists.zeus.ugent.be/cgi-bin/mailman/listinfo/projecten) en hopelijk kunnen we dan binnenkort aan het eerste project beginnen (dat zou een jabberbotje zijn in python geschreven).
+
+Binnenkort komt naast die website nog een subversion repository. (info over subversion [hier](http://web.archive.org/web/20070214144045/http://subversion.tigris.org/)) Misschien ook interessant voor projectjes die de arme studenten onder ons moeten maken. Laat ons iets weten op de projecten mailinglist als je zin hebt om mee te doen.

--- a/content/blog/05-06/stroompanne.md
+++ b/content/blog/05-06/stroompanne.md
@@ -1,0 +1,10 @@
+---
+title: Stroompanne in de kelder
+created_at: 29-05-2006
+author: appel
+---
+
+De voeding van timmy (een van onze desktop pc's in de Zeus kelder) heeft de geest gegeven,  
+hij zag het leven niet meer zitten en nam zo de helft van onze kelder met zich mee naar de duisternis.  
+Onze excuses voor de lange stroompanne, maar wegens het verlengde weekend konden wij het probleem niet verhelpen.  
+Alles zou nu terug normaal moeten werken.

--- a/content/blog/05-06/webcam.md
+++ b/content/blog/05-06/webcam.md
@@ -1,0 +1,9 @@
+---
+title: Zeus Webcam terug operationeel
+created_at: 06-12-2005
+author: Wim De Smet
+---
+
+Vanaf vandaag is de zeus webcam weer beschikbaar via de link onder "Intern" of [klik hier](http://web.archive.org/web/20070214092156/http://zeus.ugent.be:2080/index.php?menu_item=54).
+
+

--- a/content/blog/05-06/webdev-update.md
+++ b/content/blog/05-06/webdev-update.md
@@ -1,0 +1,9 @@
+---
+title: "Webdev-Lessenreeks: De Pagina"
+created_at: 28-12-2005
+author: Lieven
+---
+
+Zoals beloofd heb ik [een aantal links, voorbeeldjes en het cursusmateriaal](http://web.archive.org/web/20070730125059fw_/http://zeus.ugent.be:2080/index.php?module=webpage&action=view&i_id=124) van de voorbije webdev-lessenreeks online geplaatst.
+
+Veel plezier ermee, en Happy Coding!

--- a/content/blog/05-06/webdev.md
+++ b/content/blog/05-06/webdev.md
@@ -1,0 +1,33 @@
+---
+title: "De webdev reeks van Zeus: XHTML, CSS en PHP"
+created_at: 24-11-2005
+author: Wim De Smet
+---
+
+We openen een leeg tekstbestand en overlopen de hele weg naar je eigen stek op het Internet. Heb je dus altijd al wel eens een website willen maken... of kan een grondige heropfrissing van je skills geen kwaad? Kom dan zeker eens kijken! Voorkennis is niet vereist.
+
+Wanneer? Waar? Hoe?  
+De lessen gaan door op 29 november en op 1, 7, 8, 13 en 15 december. We starten telkens om 20u, in auditorium A0. Dat is op campus De Sterre in gebouw S9 op het gelijkvloers.
+
+Voor de liefhebbers worden er gedrukte cursussen voorzien. Had je graag een exemplaar van onze XHTML/CSS- of PHP-cursus bemachtigd, stuur dan op voorhand een mailtje naar cursus at zeus.UGent.be. (Geef wel duidelijk aan welke van beide cursussen je juist wil.) Voor leden zijn de cursussen gratis, voor de anderen zal de kostprijs niet groter zijn dan de drukkosten.
+
+
+_Hieronder vind je een overzicht van de onderwerpen die we in elke les zullen behandelen. Elke les staat zoveel mogelijk op zichzelf. Je krijgt dus hopelijk zo min mogelijk dingen te horen die je eigenlijk al weet._
+
+**Les1**: XHTML  
+Allereerst zien we hoe we de concrete inhoud van onze webpagina op een gestructureerde manier kunnen uitdrukken.
+
+**Les2**: CSS  
+Dan leren we de lay-out eigenschappen bepalen waarmee de verschillende componenten van onze site - zoals de verschillende blokken tekst, het menu en dergelijke meer - juist zullen worden weergegeven.
+
+**Les3**: PHP: Inleiding tot programmeren  
+Voor we uitleggen hoe je wat meer dynamische inhoud aan je pagina kan toevoegen geven we eerst nog een snelcursus programmeren.
+
+**Les4**: PHP: Hot Topics  
+We behandelen kort de installatie van het nodige om op je eigen PC dynamische sites te kunnen bekijken. Daarna gaan we in op een aantal courante onderwerpen zoals het werken met invoervelden, het benaderen van databanken en dergelijke meer.
+
+**Les5**: PHP: Learn-by-example  
+Om wat gewend te raken aan het programmeren van websites behandelen we een aantal korte voorbeelden.
+
+**Les6**: PHP: Een uitgewerkte case  
+Tot slot kijken we naar een wat groter en meer realistisch voorbeeld van een website in zijn geheel.

--- a/content/blog/06-07/hier-zijn-we-weer.md
+++ b/content/blog/06-07/hier-zijn-we-weer.md
@@ -1,0 +1,15 @@
+---
+title: Hier zijn we weer...
+created_at: 06-12-2006
+author: Thomas Meire
+---
+
+We weten het, we weten het: het was stil op de site, te stil. Stilte voor de storm?
+
+Een storm zit er niet meteen aan te komen, maar we hebben toch niet stilgezeten de laatste tijd. Er bleven nog wat subsidies van vorig jaar over die op moesten, en daarmee werden 2 nieuwe workstations gekocht om ons machinepark uit te breiden: bebe (een MacMini - inclusief een splinternieuw 19" tft-scherm) en Jesus (een amd64). Sinds cartman gepromoveerd werd tot nfs-server, bleven alleen timmy en chef over als workstation. Het was dus hoog tijd voor uitbreiding 😉
+
+Aanwisten zijn allemaal tof en geestig, maar die bakjes moeten geconfigureerd worden ook. En van die gelegenheid zullen we gebruikmaken om de volledige structuur van ons machinepark te herbekijken. We zouden dit op de volgende adminavond doen, en deze zou ergens in de komende week vallen (11/12 tot 15/12). We moeten juist nog eens kijken welke dag het best past voor de meesten onder ons.
+
+Naast onze alledaagse geekie bezigheden, willen we ons natuurlijk ook outen als sociaal begaafde wezens. Vandaar dat we ook nog eens een pool- of ribbetjes-avond zullen organiseren. Liefst nog voor de kerstvakantie, anders zal het waarschijnlijk pas na de examens vallen. En aangezien de komende week de enige lesweek is, is het misschien het gemakkelijkst om het ook in die week te doen? Misschien eerst adminnen en daarna ons buikje rond eten?
+
+Hoedanook, lieve vrienden, laat uw stem horen en vertel ons wanneer je vrij bent om te adminnen/eten/poolen via "bestuur AT zeus.ugent.be". De definitieve data zullen zeker nog tijdig op de site gepost worden, so stayed tuned for more...

--- a/content/blog/06-07/mailproblemen.md
+++ b/content/blog/06-07/mailproblemen.md
@@ -1,0 +1,13 @@
+---
+title: Mail op je zeus-account...
+created_at: 28-02-2007
+author: Thomas Meire
+---
+
+Blijkbaar zijn er sinds de laatste adminavond enkele problemen met de e-mail. Dit is grotendeels te wijten aan het feit dat niet alle taken reeds uitgevoerd zijn.
+
+Mensen met problemen kunnen ssh-en naar zeus.ugent.be, en daarna verder ssh-en naar kenny. Op kenny kan je dan nog je mail raadplegen aan de hand van pine of mutt. Indien je onlangs je paswoord veranderd hebt, en je imap gebruikt om je mail te bekijken, dien je je oude wachtwoord nog in te geven.
+
+Mensen met andere problemen kunnen altijd mailen naar admin at zeus.ugent.be .
+
+Maandag (05/02/2007) is er een adminavond en gaan we proberen een nieuwe mailserver in gebruik te nemen.

--- a/content/blog/06-07/netwerkproblemen.md
+++ b/content/blog/06-07/netwerkproblemen.md
@@ -1,0 +1,7 @@
+---
+title: Zeus netwerk problemen
+created_at: 18-04-2007
+author: Wim De Smet
+---
+
+Vlak voor het weekend vorige week is een gateway gecrasht vanwege een slechte videokaart. Hierdoor waren de website e.a. stukken van onze infrastructuur een aantal dagen onbereikbaar. De problemen zouden nu moeten opgelost zijn, onze excuses voor enige overlast.

--- a/content/blog/06-07/overleven-op-ugentnet.md
+++ b/content/blog/06-07/overleven-op-ugentnet.md
@@ -1,0 +1,11 @@
+---
+title: Overleven op het UGentNet
+created_at: 18-12-2006
+author: Thomas Meire
+---
+
+In 2002 brachten we voor het eerst de gids "Overleven op het UGentNet" uit, in samenwerking met de faculteit Bio-Ingenieurswetenschappen. Deze gids verschaft de UGent-student alle nodige informatie om gebruik te maken van alles wat het computernetwerk van de UGent te bieden heeft.  
+De voorbije jaren werd de gids onderhouden en bijgewerkt door Gaspard Lequeux en David De Wolf. Vanaf vandaag staat de meest recente versie terug op onze website, onder [Publicaties](https://zeus.ugent.be/index.php?menu_item=23). Deze zal vanaf nu ook permanent bijgewerkt worden, en volgend jaar verschijnt waarschijnlijk weer een gedrukte versie die verspreid zal worden over verschillende faculteiten en universitaire gebouwen.
+
+Veel plezier ermee:  
+[Overleven op UGentNet](http://web.archive.org/web/20070702045236/https://zeus.ugent.be:2443/index.php?module=webpage&action=view&i_id=128)

--- a/content/blog/06-07/thermilan----afgelast.md
+++ b/content/blog/06-07/thermilan----afgelast.md
@@ -1,6 +1,0 @@
----
-title: ThermiLAN -- AFGELAST
-created_at: 12-03-2007
----
-
-Lanparty in samenwerking met het VTK en het WiNA

--- a/content/blog/06-07/ubuntu-cd.md
+++ b/content/blog/06-07/ubuntu-cd.md
@@ -1,0 +1,11 @@
+---
+title: Ubuntu CD's
+created_at: 14-12-2006
+author: Thomas Meire
+---
+
+Deze zomer hadden we een aantal ubuntu cd's besteld om linux te verspreiden op de unif. Uiteindelijk was het zo ver: de cd'tjes zijn uitgedeeld aan de 1ste bachelors informatica. Dit semester is er helaas geen tijd meer voor een introductie tot linux, maar verwacht je er volgend semester maar aan - een datum is nog nader te bepalen.
+
+Er zijn nog cd'tjes over, dus mensen die nog eentje willen, moeten maar eens langskomen in de kelder, of mailen naar bestuur at zeus.ugent.be . De cd'tjes zullen ook beschikbaar zijn op de introductieles.
+
+(De cd's bevatten versie 6.06 LTS. Dit is niet de meest recente versie, maar wel de meest recente versie met Long Term Support (LTS), een langere ondersteuningstijd dus.)

--- a/content/blog/06-07/webcam.md
+++ b/content/blog/06-07/webcam.md
@@ -1,0 +1,13 @@
+---
+title: Webcam terug operationeel...
+created_at: 11-10-2006
+author: Thomas Meire
+---
+
+Nadat de webcam een heel eind buiten strijd geweest is, staat hij nu weer op zijn beide benen. Het is nog niet de flashy flash-versie die appel voor ogen had, maar - and I quote relix - "de vrouwen kunnen ons nu toch al weer zien".  
+Voor de gluurders onder ons, cammie staat nog altijd op zijn zelfde plaatsje.  
+Have fun with it!
+
+EDIT 14/10/1006:  
+Na heel wat geklooi met de firewalls van de gateways en een browser met de initialen IE, kan iedereen eindelijk genieten van bewegende webcambeelden, zelfs Operanen...  
+En mocht er nog een browser zijn waarin het niet werkt, laat het me dan weten via webmaster AT zeus.ugent.be

--- a/content/blog/20-21/archief.md
+++ b/content/blog/20-21/archief.md
@@ -1,0 +1,103 @@
+---
+title: "De geschiedenis in met Zeus"
+created_at: 10-05-2021
+description: "den nostaligschen tour op met Zeus"
+author: "Niko Strijbol"
+---
+
+Wie onze site bezoekt heeft nu een hoop leesvoer bijgekregen: de evenementen en blog gaan nu terug tot het jaar 2000!
+In deze blog staat kort wat/hoe er toegevoegd is, en daarna wat leuke dingen over het Zeus van weleer.
+
+## Wat en hoe?
+
+De eerste zin zei het al: de blog en evenementen zijn aangevuld tot het academiejaar 2000-2001.
+Omdat er in die tijd nog geen onderscheid was tussen blog en evenement, zijn enkel de blogposts die één-op-één overeenkwamen met een evenement ook zo toegevoegd.
+Blogposts die meerdere evenementen beschrijven zijn nog steeds een blogpost.
+
+De meeste informatie is afkomstig van de [Wayback Machine](http://web.archive.org/) (❤️ Wayback Machine).
+Het is vooral een kwestie van te bepalen onder welke domeinnaam de informatie staat. Gelukkig heeft Zeus er al een aantal gehad (waardoor de kans dat een bepaalde pagina ergens opgeslagen is groter wordt):
+
+- `zeus.ugent.be` - Dé domeinnaam (al is dat nu meer en meer `zeus.gent`). Eerste snapshot op dit domein dateert van [**8 mei 2003**](http://web.archive.org/web/20030508164101/http://www.zeus.ugent.be/).
+- `zeus.rug.ac.be` - Basically hetzelfde als hiervoor, toen de UGent nog de RUG (Rijksuniversiteit Gent) was. Het eerste snapshot hier is van [**5 oktober 1999**](http://web.archive.org/web/19991005232153/http://www.zeus.rug.ac.be/).
+- `student.rug.ac.be/zeus` - Het webadres van Zeus bij de Dienst StudentenActiviteiten. Hier is het oudste snapshot genomen op [**15 februari 1998**](http://web.archive.org/web/19980215073116/http://www.student.rug.ac.be/zeus/).
+
+Hoewel het oudste snapshot dus 15 februari 1998 is, werken de meeste foto's niet in dat snapshot om een of andere reden (met uizondering van dit [logo](http://web.archive.org/web/19990202142442/http://student.rug.ac.be/zeus/pics/zeus_k1.gif), het oudste logo van Zeus dat ik gevonden heb).
+Het oudste, deftig werkend snapshot is dat van 5 oktober 1999.
+
+De eerste versies van de website met nieuws op de startpagina verschijnen rond het jaar 2000; vanaf dan zijn alle gevonden gegevens overgezet (er zijn er [een aantal](http://web.archive.org/web/19990913001946/http://www.zeus.rug.ac.be/hotnews.shtml) van 1999, maar onze huidige site heeft moeite met 1999, dus dat zal voor een andere keer zijn).
+Dat overzetten gebeurde handmatig: uiteindelijk heeft dat twee of drie uurtjes in beslag genomen, waarschijnlijk minder lang dan als ik daar een script voor zou geschreven hebben. Waar mogelijk zijn de links vervangen door links naar de Wayback Machine, zodat de context van de blogposts en evenementen zo goed mogelijk bewaard bleef.
+
+Een klein deel van de evenementen komt ook uit de archieven van de [mailinglijst voor de leden](https://lists.zeus.ugent.be/pipermail/leden/).
+De archieven lopen van 2003 tot 2015, en zijn ook altijd interessant om te lezen (ze bevatten in het begin vooral het soort aankondigingen dat nu gebeurt via Mattermost).
+
+## Waarom?
+
+Enerzijds omdat het leuk is als er gearchiveerde data bestaat en ik, zoals iedereen, thuis zit en dus wat tijd had.
+Anderzijds kan het nut hebben: oud-leden uit die tijd kijken misschien graag vol nostalgie terug (naar bv. [het bezoek aan een brouwerij](<%= @items['/events/05-06/brouwerijbezoek.md'].path %>)).
+Nieuwere leden willen misschien inspiratie opdoen over hoe het er vroeger aan toe ging.
+Spoilers:
+
+- sommige dingen veranderen (over [PHP](<%= @items['/blog/00-01/php-lessen.md'].path %>) [zal](<%= @items['/blog/03-04/les-2.md'].path %>) [waarschijnlijk](<%= @items['/blog/05-06/webdev.md'].path %>) niet snel nog eens les gegeven worden)
+- andere zijn wat verloren geraakt (de [traditionele](<%= @items['/events/03-04/ribben.md'].path %>) [Ribbetjesavond](<%= @items['/events/02-03/ribben.md'].path %>) wordt nu soms anders ingevuld)
+- nog andere zaken blijven hetzelfde (zoals het [verkiezen van een nieuw bestuur](<%= @items['/events/05-06/ledenvergadering-3.md'].path %>) of [cammie](<%= @items['/blog/02-03/voyeur.md'].path %>), die [af en toe](<%= @items['/blog/05-06/webcam.md'].path %>) werkt).
+
+
+## Intermezzo: DSA is een Zeusproject?
+
+Een nog ouder snapshot vinden we van de [homepage van de Dienst StudentenActiviteiten](http://web.archive.org/web/19971222130916/http://student.rug.ac.be/), van 22/12/1997.
+Omdat veel leden van Zeus bij DSA werk(t)en heb je waarschijnlijk de _running gag_ al wel gehoord: "DSA is een Zeusproject".
+Nu, wat staat er onderaan de pagina van de DSA in 1997?
+
+> Deze pagina werd ontwikkeld en is onderhouden door ZEUS
+
+🤔
+
+
+## Wat is Zeus?
+
+We kijken terug naar wat Zeus toen was, om te vergelijken met Zeus in haar huidige vorm.
+Herkennen we onszelf daar nog in?
+
+De [geschiedenispagina op de oudste snapshots](http://web.archive.org/web/19980221043915/http://student.rug.ac.be:80/zeus/history.shtml) is nog exact hetzelfde als onze huidige geschiedenispagina, zij het dat de nieuwe versie wat aangevuld is.
+Dit is dus niet bijster interessant.
+
+Interessanter is de pagina [_Wat is Zeus WPI?_](http://web.archive.org/web/19980221043835/http://student.rug.ac.be:80/zeus/infozeus.shtml), waarvan we enkele fragmenten kunnen bekijken:
+
+> Zeus WPI staat voor Zeus Werkgroep Informatica. Deze werkgroep richt zich tot alles wat met informatica te maken heeft. [...] Het grootste doel van Zeus WPI is het grote publiek bekend maken met alles wat informatica aangaat.
+Zeus WPI werd gesticht in 1991, en heette toen nog Zeus Werkgroep Publieke Informatica. De volledige levenswandel van de werkgroep bestaat ook samengevat. [...]
+
+We kunnen leren dat in 1998 de W**P**I al achterhaald was, zoals het nu nog steeds is.
+
+> We hebben verschillende doelstellingen binnen Zeus WPI. Een algemeen doel is altijd het helpen van de informaticaleek en de informaticafreak op ieder vlak. Daar dit wel een heel complexe en grote zaak is hebben we enkele kleinere doelstellingen opgesteld:
+Het verspreiden van de verschillende nieuwste shareware programma's die nuttig kunnen zijn voor de studenten en personeelsleden van de universiteit. (Hier speelt natuurlijk onze FTP-server een belangrijke rol).
+Het helpen van de beginnende internetgebruikers aan de RUG. (We bieden verschillende folders aan zoals het alom bekende overleven op RUGnet)
+Het geven van raad aan iedereen die er nodig heeft.
+Sinds kort houden we er ook nog andere taken op na, zoals het onderhouden van verschillende webservers aangesloten op RUGnet.
+
+
+Het laatste stukje op deze pagina is nog het meest veranderd: Zeus biedt namelijk geen mirrors meer aan en staat niet meer in voor de distributie van software of cursussen (ook het organiseren van lessen gebeurt nog slechts sporadisch).
+Andere dingen zoals het geven van raad aan eender wie de kelder binnenwandelt gebeurt nog steeds.
+
+## Zelf rondsnuisteren
+
+Er zijn nog interessante pagina's op die snapshots:
+
+- [De mirrors](http://web.archive.org/web/20000608202730/http://www.zeus.rug.ac.be/mirrors.shtml), als je eens wilt zien wat je allemaal kon downloaden van Zeus
+- [De leden](http://web.archive.org/web/20000608171826/http://www.zeus.rug.ac.be/members.shtml) (toen nog met [proefleden](http://web.archive.org/web/20000608171826/http://www.zeus.rug.ac.be/newlid.shtml))
+- [Het machinepark van Zeus in 2000](http://web.archive.org/web/20000122025113/http://www.zeus.rug.ac.be:80/machinepark.shtml) (64 MB RAM, met 14 GB HDD voor de "Webserver, mailserver, ftpserver en backup name server voor subnet.")
+- [T-shirts van Zeus is een oude traditie](http://web.archive.org/web/20000615204502/http://www.zeus.rug.ac.be/tshirts.shtml)
+- [Het Zeus-log in 3D](http://web.archive.org/web/20000922221222/http://www.zeus.rug.ac.be/logo.jpg)
+
+Nog een kleine tip als je zelf door de historische sites aan het grasduinen bent: als je op [deze versie van de website](http://web.archive.org/web/20070128094936/http://zeus.ugent.be/) komt, zul je merken dat alle links op de pagina er zo uitzien:
+
+[`http://web.archive.org/web/20070214092156fw_/http://zeus.ugent.be:2080/index.php?menu_item=8&PHPSESSID=a91c46ab8fe8622e78359a92d9ed53ba`](http://web.archive.org/web/20070214092156fw_/http://zeus.ugent.be:2080/index.php?menu_item=8&PHPSESSID=a91c46ab8fe8622e78359a92d9ed53ba)
+
+Deze links bestaan echter niet in de Wayback Machine, maar geen probleem: als je de `PHPSESSID` verwijdert uit de URL, is de kans groot dat de link wel opgeslagen is:
+
+[`http://web.archive.org/web/20070214092156fw_/http://zeus.ugent.be:2080/index.php?menu_item=8`](http://web.archive.org/web/20070730123958fw_/http://zeus.ugent.be:2080/index.php?menu_item=8)
+
+
+Vergeet tot slot niet dat er voorheen ook al heel wat historische informatie over Zeus op onze site stond:
+
+- [Alle besturen ooit](<%= @items['/about/oud-bestuur.erb'].path %>)
+- [De volledige geschiedenis, geheel met tijdlijn](<%= @items['/about/historiek.erb'].path %>)

--- a/content/blog/20-21/archief.md
+++ b/content/blog/20-21/archief.md
@@ -21,7 +21,7 @@ Het is vooral een kwestie van te bepalen onder welke domeinnaam de informatie st
 - `zeus.rug.ac.be` - Basically hetzelfde als hiervoor, toen de UGent nog de RUG (Rijksuniversiteit Gent) was. Het eerste snapshot hier is van [**5 oktober 1999**](http://web.archive.org/web/19991005232153/http://www.zeus.rug.ac.be/).
 - `student.rug.ac.be/zeus` - Het webadres van Zeus bij de Dienst StudentenActiviteiten. Hier is het oudste snapshot genomen op [**15 februari 1998**](http://web.archive.org/web/19980215073116/http://www.student.rug.ac.be/zeus/).
 
-Hoewel het oudste snapshot dus 15 februari 1998 is, werken de meeste foto's niet in dat snapshot om een of andere reden (met uizondering van dit [logo](http://web.archive.org/web/19990202142442/http://student.rug.ac.be/zeus/pics/zeus_k1.gif), het oudste logo van Zeus dat ik gevonden heb).
+Hoewel het oudste snapshot dus 15 februari 1998 is, werken de meeste foto's niet in dat snapshot om een of andere reden (met uitzondering van dit [logo](http://web.archive.org/web/19990202142442/http://student.rug.ac.be/zeus/pics/zeus_k1.gif), het oudste logo van Zeus dat ik gevonden heb).
 Het oudste, deftig werkend snapshot is dat van 5 oktober 1999.
 
 De eerste versies van de website met nieuws op de startpagina verschijnen rond het jaar 2000; vanaf dan zijn alle gevonden gegevens overgezet (er zijn er [een aantal](http://web.archive.org/web/19990913001946/http://www.zeus.rug.ac.be/hotnews.shtml) van 1999, maar onze huidige site heeft moeite met 1999, dus dat zal voor een andere keer zijn).
@@ -86,7 +86,7 @@ Er zijn nog interessante pagina's op die snapshots:
 - [De leden](http://web.archive.org/web/20000608171826/http://www.zeus.rug.ac.be/members.shtml) (toen nog met [proefleden](http://web.archive.org/web/20000608171826/http://www.zeus.rug.ac.be/newlid.shtml))
 - [Het machinepark van Zeus in 2000](http://web.archive.org/web/20000122025113/http://www.zeus.rug.ac.be:80/machinepark.shtml) (64 MB RAM, met 14 GB HDD voor de "Webserver, mailserver, ftpserver en backup name server voor subnet.")
 - [T-shirts van Zeus is een oude traditie](http://web.archive.org/web/20000615204502/http://www.zeus.rug.ac.be/tshirts.shtml)
-- [Het Zeus-log in 3D](http://web.archive.org/web/20000922221222/http://www.zeus.rug.ac.be/logo.jpg)
+- [Het Zeus-logo in 3D](http://web.archive.org/web/20000922221222/http://www.zeus.rug.ac.be/logo.jpg)
 
 Nog een kleine tip als je zelf door de historische sites aan het grasduinen bent: als je op [deze versie van de website](http://web.archive.org/web/20070128094936/http://zeus.ugent.be/) komt, zul je merken dat alle links op de pagina er zo uitzien:
 

--- a/content/events/00-01/ledenvergadering.md
+++ b/content/events/00-01/ledenvergadering.md
@@ -1,0 +1,10 @@
+---
+title: Ledenvergadering Belangrijk!
+created_at: 10-10-2000
+time: 17-10-2000 19:00
+location: Galglaan, campus de Sterre
+---
+
+Alle leden en mogelijkst geintresseerde nieuwe leden worden vriendelijk uitgenodigd op de ledenvergadering van Zeus WPI. Deze gaat door op 17 oktober 2000 in de Galglaan (campus de Sterre) om 19:00. Alle nieuwe leden worden verzocht te komen! Indien je niet kan komen, laat het ons weten.
+
+_Noot van de archivaris: de aanmaakdatum van dit evenement is een schatting._

--- a/content/events/01-02/bowling.md
+++ b/content/events/01-02/bowling.md
@@ -1,0 +1,13 @@
+---
+title: Zeus gaat bowlen.
+created_at: 01-11-2001
+time: 14-11-2001 18:30
+location: De Brug
+---
+
+Op 14 november gaan we samen met de OAK bowlen. Voor meer informatie of inschrijvingen stuur je een mailtje naar Milena.
+
+We vertrekken om 18.30u stipt MET de FIETS vanaf De Brug (verzamelen om 18.20u!!!) richting bowling De Meibloem (Meibloemstraat 18).
+
+
+_Noot van de archivaris: de aanmaakdatum van dit evenement is een schatting._

--- a/content/events/01-02/ledenvergadering-2.md
+++ b/content/events/01-02/ledenvergadering-2.md
@@ -1,0 +1,15 @@
+---
+title: 15 mei = Ledenvergadering !!!
+created_at: 01-05-2002
+time: 15-05-2002 18:00
+location: Cage-gebouwen
+---
+
+Op woensdag 15 mei om 18h is er een ledenvergadering. Deze zal doorgaan in het Cage complex (Galglaan).
+
+Tijdens deze vergadering zullen we o.a. de bestuurs-functies voor volgend jaar bespreken. Het is dus belangrijk dat alle leden aanwezig zijn !
+
+Mensen die interesse hebben om volgend jaar in het bestuur van Zeus te zitten (ook bestuursleden van nu die hun 'mandaat' willen vernieuwen) sturen best een mailtje naar bestuur@zeus.rug.ac.be met eventueel een motivatie (ja reeds voor de vergadering)
+
+
+_Noot van de archivaris: de aanmaakdatum van dit evenement is een schatting._

--- a/content/events/01-02/ledenvergadering.md
+++ b/content/events/01-02/ledenvergadering.md
@@ -1,0 +1,11 @@
+---
+title: Volgende ledenvergadering.
+created_at: 01-11-2001
+time: 12-11-2001 18:00
+location: Cage-gebouwen
+---
+
+Maandag 12 november om 18uur is er een ledenvergadering in de Cage-gebouwen. De [projecten](http://web.archive.org/web/20011127170659/http://www.zeus.rug.ac.be:80/projects.shtml) van dit semester worden besproken.
+
+
+_Noot van de archivaris: de aanmaakdatum van dit evenement is een schatting._

--- a/content/events/01-02/spam.md
+++ b/content/events/01-02/spam.md
@@ -1,0 +1,16 @@
+---
+title: Anti spam les
+created_at: 01-03-2002
+time: 27-03-2002 18:30
+location: Auditorium A0, S9
+locationlink: $s9
+---
+
+18h30, gebouw S9 campus de Sterre, audiotorium A0. Inschrijven verplicht!
+
+Hoef je geen nieuwe lening? Interesseert een hypotheek je niet? Geen behoefte aan porno? Tevreden met de omvang van je lichaam en haar onderdelen en prestaties? Geen interesse in aandelen, superaanbiedingen, manieren om ongeloofijk snel stinkend rijk te worden etc?
+
+Indien je antwoorden op bovenstaande vragen voornamelijk "ja"zijn en je toch voortdurend gebombardeerd wordt met emails die je dat alles en nog veel meer proberen aan te smeren, dan heb je al kennis gemaakt met het fenomeen dat "spam"genoemd wordt. [Meer info](http://web.archive.org/web/20020402151005/http://www.zeus.rug.ac.be:80/pub.shtml)
+
+
+_Noot van de archivaris: de aanmaakdatum van dit evenement is een schatting._

--- a/content/events/02-03/ribben.md
+++ b/content/events/02-03/ribben.md
@@ -1,0 +1,37 @@
+---
+title: Zeus eet ribbetjes
+created_at: 22-04-2003
+time: 29-04-2003 19:30
+location: Gekroonde Hoofden
+locationlink: Gekroonde Hoofden, Ghent Belgium
+---
+
+Het is weer zover, Zeus gaat terug eens *ribbetjes* eten.  Dit op
+*dinsdag 29 april*.  In de *gekroonde hoofden* te Gent.
+
+En dit om 19u30.
+
+Als je meewilt gelieve te reageren naar mij (rudy at zeus) met in de
+subject:
+
+ribbetjes X
+
+Waarbij X het aantal personen is die je wenst mee te brengen
+(inclusief jezelf).  Hoe meer zielen hoe meer vreugde.  Als ge een
+lief/vriend hebt, breng die dan eens mee.
+
+In de gekroonde hoofden kun je naast ribbetjes ook nog andere dingen
+eten.  Keus genoeg!  Twee jaar geleden zijn we al eens geweest en
+waren we met een stuk of 15 geloof ik.
+
+De ribbetjes zijn a volente en je hebt keuze uit 4 smaken:
+
+- van de chef (is pikant)
+- honing
+- zoetzuur
+- en nog iets waarvan ik het niet meer weet.
+
+Kostprijs ongeveer 13 euro geloof ik.  Dus daarvoor moet je het niet
+laten, eet desnoods twee dagen niets want het is A VOLENTE!
+
+Tot dan!

--- a/content/events/02-03/spam.md
+++ b/content/events/02-03/spam.md
@@ -1,0 +1,11 @@
+---
+title: ANTI-Spamles
+created_at: 09-05-2003
+time: 13-05-2003 18:00
+location: Auditorium A2, S9
+locationlink: $s9
+---
+
+Als je wil weten hoe de spammers te werk gaan, hoe ze proberen te verbergen vanwaar hun emails komen en waar hun websites gehost worden en wat je er tegen kan doen, dan is de cursus "Spam: wat doe ik eraan?" zeker iets voor jou. We bekijken hoe het SMTP protocol (dat gebruikt wordt om mails te versturen) werkt en hoe je emails moet traceren, wat open relays en proxy's zijn en hoe ze misbruikt worden door spammers, hoe web pagina's door spammers gecodeerd worden en manieren om ze te ontcijferen, etc.
+
+De les gaat door op dinsdag 13 mei, om 18.00, en dit in auditorium A2, S9, Capus Sterre (en dus niet op de eerder aangekondigde datum). Zoals steeds is iedereen welkom. Als je wil komen, mail dan even naar lessen@zeus.rug.ac.be, en vermeld erbij of je een gedrukte cursus wilt

--- a/content/events/02-03/stallman.md
+++ b/content/events/02-03/stallman.md
@@ -1,0 +1,12 @@
+---
+title: "ZeusWPI presents: Richard Stallman"
+created_at: 10-02-2003
+time: 09-05-2007 19:00
+location: Auditorium A1 - S9
+locationlink: $s9
+---
+
+Update: De voordracht van RMS werd goed gesmaakt door de aanwezigen. Foto's van de voordracht zijn te vinden op: [http://cage.rug.ac.be/~gvernaev/stallmanzeus](http://web.archive.org/web/20050506174605/http://cage.ugent.be/~gvernaev/stallmanzeus/) en hier - Geïnteresseerden kunnen [deze](http://web.archive.org/web/20070630085501/http://www.researchoninnovation.org/patent.pdf) interessante pdf-file eens lezen, die RMS vermeldde in zijn speech.
+
+Richard Stallman (RMS) will be giving a speech on the danger of software patents. - Richard Stallman geeft voor Zeus WPI een voordracht over de gevaren van gepatenteerde software. - [More info](http://web.archive.org/web/20040521070955/http://studwww.rug.ac.be/~rgevaert/rmsaffiche.pdf).
+Iedereen die geïnteresseerd is is welkom; inschrijven hoeft niet. - Everybody is invited; no reservation required.

--- a/content/events/03-04/bowlen.md
+++ b/content/events/03-04/bowlen.md
@@ -1,0 +1,9 @@
+---
+title: Bowling
+created_at: 02-10-2003
+time: 29-10-2003 19:00
+location: Therminal
+locationlink: $therminal
+---
+
+Op 29 oktober gaan we bowlen. Verdere details volgen later nog.

--- a/content/events/03-04/gnupg.md
+++ b/content/events/03-04/gnupg.md
@@ -1,0 +1,10 @@
+---
+title: Les GNUPG
+created_at: 23-02-2004
+time: 01-03-2004 18:00
+location: Auditorium A1, S9
+locationlink: $s9
+---
+
+Op maandag 1 maart, van 18 tot 20u organiseert Zeus een les GNUPG, met aansluitende keysigning party. Deze gaat door in auditorium A1, gebouw S9, campus de Sterre. Als je komt, stuur dan even een mailtje naar lessen@zeus.ugent.be.
+

--- a/content/events/03-04/ledenvergadering-2.md
+++ b/content/events/03-04/ledenvergadering-2.md
@@ -1,0 +1,22 @@
+---
+title: Ledenvergadering II
+created_at: 17-02-2004
+time: 25-02-2004 18:30
+location: De Brug
+---
+
+Een nog onbevlekt tweede semester ligt voor de boeg... Hoog tijd dus om
+tussen pot en pint de komende activiteiten op een rijtje te zetten.
+
+Zouden we niet nog eens ribbetjes gaan eten? Of op FOSDEM gaan
+kijken? Wat van de geruchten dat er een jabber server zou worden
+opgezet? En zouden de T-Shirts eindelijk gearriveerd zijn?
+Misschien moesten we eens onze stoute schoenen aantrekken en op
+kroegentocht gaan... Of op FreeEDEM (www.freeedem.org) naar Rudy's
+voordracht over GLMS gaan luisteren.
+
+Zou het niet tof zijn om een les te organiseren over GPG? Of over
+Jabber? En zouden we onze PHP-les niet nog eens van stal halen?
+
+U hoort het allemaal, volgende week WOENSDAG 25 FEBRUARI 2004, om
+1830hrs in de BRUG.

--- a/content/events/03-04/ledenvergadering.md
+++ b/content/events/03-04/ledenvergadering.md
@@ -1,0 +1,8 @@
+---
+title: Ledenvergadering
+created_at: 02-10-2003
+time: 14-10-2003 19:00
+location: De Brug
+---
+
+Op dinsdag 14 oktober om 19.00u houden we in De Brug onze eerste ledenvergadering van het nieuwe Zeusjaar. Er wordt gekozen voor de Brug vanwege de nabijgelegen cafeetjes (na de vergadering dus). Alle leden: be there! By the way, Zeus zal ook aanwezig zijn op Gent Ontgroent op 8 oktober. Kom eens langs in studentenresto leden: be there!

--- a/content/events/03-04/ribben.md
+++ b/content/events/03-04/ribben.md
@@ -1,0 +1,16 @@
+---
+title: zeus etentje
+created_at: 10-04-2004
+time: 29-04-2004 19:00
+location: Amadeus
+locationlink: Plotersgracht 8, 9000 Gent
+---
+
+Zoals jaarlijks gaan we weer eens gezamenlijk bouffen met zeus.  Deze
+keer een iets hoogstaander menu dan op de kroegentocht. (cfr.
+http://www.zeus.ugent.be/~kris/stuff/zeus-kroegentocht-260304/sany0038.jpg)
+We gaan opnieuw ribbetjes eten zoals vorig jaar, maar deze keer bij
+Amadeus.  Dit gaat door op donderdag 29 april.
+
+Om te kunnen inschatten hoeveel plaatsen we moeten reserveren had ik
+graag een mailtje gekregen van voordien of je komt.

--- a/content/events/04-05/bowling.md
+++ b/content/events/04-05/bowling.md
@@ -1,0 +1,8 @@
+---
+title: Zeus bowlt!
+created_at: 3-11-2004
+time: 3-11-2004 19:00
+location: Meibloemstraat 18-20
+---
+
+Vanavond stunten we met zware dingen in bowlinghal "de Meibloem" (Meibloemstraat 18-20). De colonne per fiets vertrekt om 18u30 aan de Brug. Afspraak omstreeks 19u00 ter plaatse.

--- a/content/events/04-05/lamport.md
+++ b/content/events/04-05/lamport.md
@@ -1,0 +1,21 @@
+---
+title: Lezing Dr. Leslie Lamport
+created_at: 31-10-2004
+time: 17-11-2004 18:00
+location: S9
+locationlink: $s9
+---
+
+Zeus presenteert:
+
+> Dr. Leslie Lamport<br>
+> Thinking for Programmers
+
+Wanneer: woensdag 17 november, 18.00 uur<br>
+Waar: Campus "De Sterre", Gebouw S9, Krijgslaan 281, Gent
+
+GRATIS TOEGANG
+
+Abstract: "There is a very effective software development tool that is not used nearly enough--the brain. The many impediments to its proper use devised by computer scientists can be overcome."
+
+De affiche kan je [hier](http://web.archive.org/web/20041115180039/http://zeus.ugent.be/~tiemelijn/tests/affiche_leslie.pdf) bekijken.

--- a/content/events/04-05/ledenvergadering-2.md
+++ b/content/events/04-05/ledenvergadering-2.md
@@ -1,0 +1,16 @@
+---
+title: Ledenvergadering
+created_at: 17-02-2005
+time: 24-02-2005 20:00
+location: De Brug
+---
+
+Yo!
+
+Nu de eerste examenperiode alweer achter ons ligt en we weer volop van het vrije leven kunnen genieten lijkt geen moment beter geschikt om uit te doeken te doen wat Zeus deze semester allemaal te bieden heeft.
+
+Stop daarom aanstaande donderdag 24 februari 2005 om 2000hrs even met repetitief de 'Mijn resultaten'-pagina op Minerva te herladen en zak af naar Studentenhuis "De Brug"! De ledenvergadering zal doorgaan in de Fotoklas op de tweede verdieping (neem bij het binnenkomen de eerste paar trappen, ga dan rechts door de glazen deur en pak daar verder de trap omhoog).
+
+Uiteraard is het bestuur niet verantwoordelijk voor het gebeurlijke afzakken naar de Deffoo en de daaropvolgende overmatige consumtie van houten koppen.
+
+Tot dan!

--- a/content/events/04-05/ledenvergadering.md
+++ b/content/events/04-05/ledenvergadering.md
@@ -1,0 +1,10 @@
+---
+title: Ledenvergadering
+created_at: 08-10-2004
+time: 12-10-2004 19:00
+location: De Brug
+---
+
+Het eerste weekje academiejaar zit er weer ver op. Hoog tijd dus om nog eens een ledenvergadering op poten te zetten. Kom als eerste te weten wat we dit jaar allemaal gaan uitsteken: Zal er zowaar een cultuur pre^H^H^H verantwoordelijke zijn? Zal er gedweild worden in de kelder? En zal ik het weer 3 uur rekken voor we een pint gaan drinken? Dit en andere zaken van levensbelang hoor je allemaal nu dinsdag 12 oktober om 1900hrs. Afspraak aan de ingang van studentenhuis "De Brug" (Sint Pietersnieuwstraat 45).
+
+**Update**: Zoals beloofd volgt hier een korte wegbeschrijving voor de eerste bachelors. Als je er even het [kaartje](http://web.archive.org/web/20041130073516/http://www.zeus.ugent.be/~simkin/stpietersplein.png) bijneemt (dank aan mappy.com) zie je onderaan het Sint-Pietersplein. Het lelijke kruisje poogt het adviescentrum voor studenten (waar je je bent gaan inschrijven) aan te geven. De Sint-Pietersnieuwstraat loopt op de kaart ongeveer recht naar boven. Studentenhuis "De Brug" is huisnummer 45.

--- a/content/events/04-05/python.md
+++ b/content/events/04-05/python.md
@@ -1,0 +1,13 @@
+---
+title: Onderonsje over Python
+created_at: 03-05-2005
+time: 10-05-2005 19:00
+location: Zeus-kelder
+locationlink: $kelder
+---
+
+Aanstaande **dinsdag 10 mei** vertelt Wim ons over zijn learning experience met **de programmeertaal Python**.
+
+Python is een **eenvoudige, object-geörienteerde en geïnterpreteerde taal**. Samen met talen als Ruby en Perl begint hij steeds meer zijn intrede te doen als **hoge niveau taal voor een breed scala aan toepassingen** -- gaande van webtoepassingen tot desktop applicaties.
+
+We hopen tegen volgend academiejaar een volwaardige Python les(senreeks) klaar te stomen. Voorlopig houden we het echter eerder low profile: afspraak in de **Zeus bunker** om **1900hrs**.

--- a/content/events/04-05/ribben.md
+++ b/content/events/04-05/ribben.md
@@ -1,0 +1,17 @@
+---
+title: Zeus eet ribbetjes
+created_at: 29-04-2005
+time: 11-05-2005 19:00
+location: Amadeus
+locationlink: Plotersgracht 8, 9000 Gent
+---
+
+Ook dit jaar gaan we er uit met een hippe spetterende **ribbetjes-eet activiteit**. We trekken hiervoor weerom naar restaurant **Amadeus**, en dit op **woensdag 11 mei** om **1900hrs**.
+
+Het restaurant is gelegen in het pittoreske patershol, meerbepaald in de **Plotersgracht 8-10**. Wie zich niet zo zeker voelt in het ontwarren van het middeleeuws stratennetwerk en over een **fiets** beschikt kan zich ook om **1830hrs** met zijn rijtuig naar de ingang van **studentenhuis "De Brug"** begeven. Iemand van het bestuur zal dan van daaruit de weg leiden.
+
+Na het eetfestijn trekken we uiteraard nog eens de binnenstad in voor een afterdrinkje of twee drie vier.
+
+Ben je verkocht? Stuur dan vlug een mailtje naar bestuur at zeus.UGent.be om te laten weten dat je komt! Vermeld ook de grootte van je entourage, zodat we de uitbater een idee kunnen geven van het aantal gegadigden.
+
+Tot dan!

--- a/content/events/05-06/adminavond.md
+++ b/content/events/05-06/adminavond.md
@@ -1,0 +1,11 @@
+---
+title: "Dinsdag 16 mei: adminavond"
+created_at: 10-05-2006
+time: 16-05-2006
+location: Zeus-kelder
+locationlink: $kelder
+---
+
+Het wordt weer eens tijd om alles onder handen te nemen eer de examens beginnen en het jaar voorbij is. Dus volgende dinsdag zullen we de services migreren en een aantal andere dingen tot voltooiing brengen die op de vergadering besproken zijn.
+
+Alle leden zijn welkom om eens te komen kijken wat er allemaal bekokstoofd wordt. Breng gerust iets te eten of te drinken mee om de hongerige admins te voederen. Geen vingers tussen de tralies steken!

--- a/content/events/05-06/brouwerijbezoek.md
+++ b/content/events/05-06/brouwerijbezoek.md
@@ -1,0 +1,12 @@
+---
+title: "Brouwerijbezoek: Zeus goes Bosteels"
+created_at: 08-11-2005
+time: 21-11-2005 13:00
+location: Brouwerij Bosteels in Buggenhout
+---
+
+Maandag 21 november is het zover: Zeus' eerste brouwerijbezoek. We trekken naar brouwerij Bosteels in Buggenhout, bekend van Kwak, Tripel Karmeliet, 't Zelfde en DeuS: Brut des Flandres. Regelmatige winnaar op de World Beer Cup en World Beer Championships.
+
+We verzamelen om 13 uur in de inkomhal van station Gent-Sint-Pieters. Wees op tijd, treinen wachten niet! De terugkomst wordt geschat rond 18 uur. -26 jarigen betalen 9 euro voor brouwerijbezoek en reiskosten (heen en terug). De rest betaalt zijn eigen ticket + 3.50 euro voor het brouwerijbezoek.
+
+Als je wilt meegaan, stuur dan een mail naar bestuur at zeus.ugent.be waarin je aangeeft met hoeveel personen je zal zijn (lidmaatschap niet verplicht), en hoeveel daarvan op de Zeus Go Pass willen staan. Schrijf je zo snel mogelijk in, want de plaatsen zijn beperkt!

--- a/content/events/05-06/fosdem.md
+++ b/content/events/05-06/fosdem.md
@@ -1,0 +1,10 @@
+---
+title: "FOSDEM 2006"
+created_at: 21-02-2006
+time: 25-02-2006 09:15
+location: Station Gent-Sint-Pieters
+---
+
+Naar aloude gewoonte gaat Zeus dit jaar weer naar FOSDEM. We vertrekken deze zaterdag met de trein van 09u22 uit Gent en verzamelen om 09u15 op het perron. Een kleine tegemoetkoming in de prijs van het ticket zal voorzien worden, mits u meespoort op onze go pass. Voor zeus niet-leden, laat eens weten of je met ons mee wilt rijden op bestuur at zeus.ugent.be zodat we weten hoeveel externen er ongeveer meegaan.
+
+Meer informatie over FOSDEM op [http://www.fosdem.be/](https://archive.fosdem.org/2006/)

--- a/content/events/05-06/ledenvergadering-2.md
+++ b/content/events/05-06/ledenvergadering-2.md
@@ -1,0 +1,12 @@
+---
+title: Eerste ledenvergadering 2006
+created_at: 15-02-2006
+time: 20-02-2006 19:00
+location: De Brug
+---
+
+Een nieuw semester is weer begonnen, tijd voor een tweede ledenvergadering. De eerste ledenvergadering van dit jaar gaat door op maandag 20 februari, om 19u, in studentenhuis De Brug. Alle leden zijn uitgenodigd en worden daar verwacht. Aspirant-leden zijn zoals altijd welkom.
+
+We zullen vooral de verschillende adminprojecten (o.a. migratie van diensten) bespreken en de status van huidige softwareprojecten. Verder zijn er verschillende leden geinteresseerd in de implementatie van een aantal nieuwe projecten en zal daar dus ruim aandacht aan besteed worden. Als laatste kijken we ook even vooruit naar het nieuwe jaar, meer bepaald polsen we even naar kandidaten voor het bestuur van volgend jaar.
+
+Alvast tot maandag!

--- a/content/events/05-06/ledenvergadering-3.md
+++ b/content/events/05-06/ledenvergadering-3.md
@@ -1,0 +1,18 @@
+---
+title: Laatste ledenvergadering 2005-2006
+created_at: 01-05-2006
+time: 09-05-2006 19:00
+location: De Therminal
+locationlink: $therminal
+---
+
+De examens komen er weer aan en het is dus tijd om onze laatste ledenvergadering te organiseren.
+
+Dingen op de agenda:
+
+- admin troubles
+- last minute activiteiten
+- status van de subsidies
+- verkiezing nieuw bestuur.
+
+De vergadering zal van start gaan dinsdag 9 mei om 19u15 in studentenhuis de Therminal, gelieve vanaf 19u aan de ingang te verzamelen.

--- a/content/events/05-06/ledenvergadering.md
+++ b/content/events/05-06/ledenvergadering.md
@@ -1,0 +1,14 @@
+---
+title: Eerste ledenvergadering
+created_at: 08-10-2004
+time: 12-10-2004 19:00
+location: De Brug
+---
+
+Het is weer zover: een nieuw jaar, een nieuw bestuur en (hopelijk) nieuwe leden. Alle huidige leden en aspirant-leden worden dan ook verwacht op de eerste ledenvergadering. Deze keer gaat de ledenvergadering door op woensdag 19 oktober om 19u30 in studentenhuis De Brug. De zaal zal later nog bekend gemaakt worden.
+
+Weet je studentenhuis De Brug niet zijn, [hier is een kaartje](http://web.archive.org/web/20070731123411/http://endymion.ugent.be/~simkin/stpietersplein.png). Als je er even het kaartje bijneemt (dank aan mappy.com) zie je onderaan het Sint-Pietersplein. Het lelijke kruisje poogt het adviescentrum voor studenten (waar je je bent gaan inschrijven) aan te geven. De Sint-Pietersnieuwstraat loopt op de kaart ongeveer recht naar boven. Studentenhuis "De Brug" is huisnummer 45.
+
+Kun je deze keer spijtig genoeg niet komen maar wil je toch lid worden? Laat ons iets weten op bestuur at zeus.ugent.be en we spreken eens af in de S9.
+
+**Update**: De vergadering gaat door in de zaal "Raad van Bestuur" op het gelijkvloers om 19u30. Een (iets beter) kaartje vind je [hier](http://zeus.ugent.be/~kromagg/debrug.png). (bovenaan plateau, onderaan sint-pietersplein, de "blauwe bol" duidt De Brug aan)

--- a/content/events/06-07/adminavond-2.md
+++ b/content/events/06-07/adminavond-2.md
@@ -1,0 +1,22 @@
+---
+title: Zeus Adminavond
+created_at: 04-03-2007
+time: 05-03-2006 19:00
+location: Zeus-kelder
+locationlink: $kelder
+---
+
+Morgen, maandag 5 maart, is er weer een adminavond.  
+De (lange) avond begint rond 19u, omdat we nogal wat werk moeten verrichten.
+
+Op de planning staan onder andere:  
+de mail in orde brengen (m.a.w. kenny weg),  
+de mailinglists in orde brengen (cfr. mail),  
+de sites allemaal op mephisto onder een nieuwe account (data wel op cartman),  
+nieuwe gateways installeren,  
+drivers van jesus in orde brengen,  
+timmy eens goed nakijken,  
+wendy (de printer) van naam veranderen en kijken of hij/zij een beetje betrouwbaar is,  
+...
+
+Het is duidelijk dat dit een hoop werk zal zijn en daarom zou het handig dat zoveel mogelijk volk morgen naar de kelder afzakt!

--- a/content/events/06-07/adminavond.md
+++ b/content/events/06-07/adminavond.md
@@ -1,0 +1,22 @@
+---
+title: Adminavond donderdag 14 december
+created_at: 11-12-2006
+time: 14-12-2006 19:00
+location: Zeus-kelder
+locationlink: $kelder
+---
+
+Kwestie van de activiteiten eens vooraf aan te kondigen: **nu donderdag adminavond!**  
+We verwachten de admins en geïnteresseerde leden rond 19 uur in de kelder.
+
+Op de planning staat een volledige herorganisatie van ons netwerkje en herinstallatie van een aantal servers.
+
+Bezoekers mogen ons steeds komen voeden.
+
+UPDATE 14/12:
+
+* 20:25 :: Maarten is ldap aant het installeren op cartman, Ken installeert Dapper Drake op timmy en Bart is bezig butters te herinstalleren. Tom speelt met bébé en Christophe & David houden een intiem onderonsje in het pc-lokaal van de S9 😉.
+
+* 22:45 :: Timmy is volledig geherinstalleerd, weliswaar na een harddiskwissel. Kevin heeft ons ondertussen vervoegd en heeft zich over de configuratie van de website ontfermd. Maarten heeft ondertussen de ldap naar cartman overgezet.
+
+* 1:06 :: Maarten is erin geslaagd de ldap succesvol over te zetten naar cartman. Alle logins gebeuren nu via cartman en shelly is dus overbodig. Timmy is nu wel helaas wat weerspannig. Butters is geconfigureerd als gateway en bijna klaar om ingeschakeld te worden. Choksondik werd eveneens geherinstalleerd. Zeus.ugent.be zou in principe rechtsreeks naar mephisto kunnen wijzen (ipv. de omweg via Kenny), maar list.zeus.ugent.be werkt nog tegen: de files daarvoor staan alleen op kenny (we kunnen daardoor niet alle http zomaar naar mephisto zenden). Garisson is nu de default ssh-server. Wanneer je inlogt, word je nu dus verwelkomd door garisson ☺️ En nu is 't gedaan met de adminavond! Slaapwel...

--- a/content/events/06-07/fosdem.md
+++ b/content/events/06-07/fosdem.md
@@ -1,0 +1,19 @@
+---
+title: "FOSDEM 24/02/2007"
+created_at: 22-02-2007
+time: 24-02-2007 09:00
+location: Station Gent-Sint-Pieters
+---
+
+Zeus WPI gaat ook dit jaar weer naar Fosdem. Fosdem staat voor Free and Open Source Software Developer's European Meeting. 2 dagen lang kan je presentaties en discussies bijwonen over verschillende projecten en thema's.
+
+Onderwerpen die aan bod komen:
+
+- Security
+- Desktop Applications
+- Development and Languages
+- Kernel
+- Web
+- Internet Services
+  
+Wil je ook meegaan, kom dan zaterdag 24 februari om 9:00 naar de vertrekhal van het sint pietersstation. Vertrek je liever van ergens anders maar ga je toch graag mee, laat het ons dan weten door te mailen naar bestuur at zeus.ugent.be en dan kunnen we afspreken om elkaar in Brussel te ontmoeten. Meer info kan je vinden op [http://www.fosdem.org/](https://archive.fosdem.org/2007/). Hopelijk tot dan!

--- a/content/events/06-07/ledenvergadering-1.md
+++ b/content/events/06-07/ledenvergadering-1.md
@@ -1,0 +1,12 @@
+---
+title: Eerste ledenvergadering
+created_at: 11-10-2006
+time: 11-10-2006 19:00
+location: Therminal
+locationlink: $therminal
+---
+
+Het nieuwe academiejaar is weer van start gegaan en dus ook het nieuwe Zeus jaar. Deze woensdag (11/10/2006, vandaag dus) is het de allereerste ledenvergadering van het jaar. Deze zal plaatsvinden om 19u in De Therminal, vergaderzaal 2. Bij deze is iedereen uitgenodigd en hopen wij dat zoveel mogelijk mensen komen opdagen.
+Wat er zoal gedaan zal worden: nieuwe bestuur voorstellen (voor diegene die ons nog niet kennen), activiteiten bespreken, ... Uiteraard zal dit opgevolgd worden door een goede pint (of iets anders) !
+
+Vele groeten, en hopelijk tot daar.

--- a/content/events/06-07/ledenvergadering-2.md
+++ b/content/events/06-07/ledenvergadering-2.md
@@ -1,0 +1,18 @@
+---
+title: Ledenvergadering 21/02
+created_at: 20-02-2007
+time: 21-02-2007 19:00
+location: kot van onze venetiaanse voorzitter Willem
+---
+
+Nu het nieuwe semester alweer een weekje bezig is, en we allemaal uitgerust zijn door de nieuwe vakantie, wordt het weer eens tijd om een ledenvergadering op touw te zetten.
+
+Op de agenda zullen onder andere de volgende puntjes staan:
+
+* Adminnen: go where no man has gone before (lees: afwerken van wat we vorig semester uitgespookt hebben)
+* Fighting the [SPAM]
+* Komende activiteiten: FOSDEM, Brouwerijbezoek, ribbetjesavond, lessen,...
+* Subsidies (Wat te doen met...)
+* ...
+
+We spreken af op woensdag 21 februari op het kot van onze venetiaanse voorzitter Willem (St-Pietersnieuwstraat nr 216) om 19u00. Wie te laat is krijgt geen koekje. Wie op tijd is ook niet, tenzij er iemand koekjes meebrengt. Achteraf wordt er afgezakt naar het stamcafé.

--- a/content/events/06-07/thermilan----afgelast.md
+++ b/content/events/06-07/thermilan----afgelast.md
@@ -1,0 +1,14 @@
+---
+title: ThermiLAN in samenwerking met Wina en VTK -- AFGELAST--
+created_at: 18-03-2007
+time: 23-03-2007
+location: De Therminal
+locationlink: $therminal
+---
+
+EDIT: Spijtig genoeg moet ik jullie melden dat Thermilan toch niet zal doorgaan door o.a. het zeer lage aantal inschrijvingen. Sorry voor de mensen die toch nog wilden komen. Alvast bedankt voor jullie begrip.
+
+Het is enkelen van jullie misschien al opgevallen dat Zeus WPI dit jaar samen met Wina en VTK een LAN party organiseert. Deze zal doorgaan op 23 - 24 - 25 maart 2007 in de Therminal en biedt plaats aan 60 gamers. Je moet wel je eigen PC meebrengen, de LAN party gaat niet door in PC-zalen. Inschrijven kan nog steeds. Meer informatie vindt je op http://student.ugent.be/thermilan .
+
+Ben je niet echt een gamer (zoals ik) dan is het misschien het ideale moment om samen te komen en te spelen met Linux, software schrijven, ....
+Hopelijk tot dan!

--- a/data/bestuur.yaml
+++ b/data/bestuur.yaml
@@ -127,7 +127,7 @@ data:
     - rol: Vicevoorzitter
       naam: Dries Kimpe
     - rol: Penningmeester
-      naam: Rudi Gevaert
+      naam: Rudy Gevaert
   03-04:
     - rol: Voorzitter
       naam: Kristof Verhenne


### PR DESCRIPTION
Deze PR vult de evenementen en blogposts aan met alle beschikbare data; ze gaan terug tot het jaar 2000 -- de eerste Zeus-sites hadden geen nieuws. De data komt voornamelijk van de Wayback Machine (ik had eens wat tijd vanavond).

Editoriale opmerkingen:

- Vroege versies van de Zeus-site hadden een soort "nieuws"-ding, dat meer gebruikt werd voor kleine aankondigingen (die nu vaak in Mattermost komen ipv op de blog), dus het gebruik van de de blog toen verschilt wel lichtjes tegenover het huidige gebruik
- Blogposts die één-op-één mapten met een event zijn ook als event toegevoegd; waren er bv. meerdere evenementen in één blogpost heb ik dat niet gedaan.
- Een zeer klein aantal evenementen zijn uit de archieven van de ledenlijst gehaald (één of twee ribbetjesavonden)
- Waar mogelijk heb ik de links vervangen door links naar de Wayback Machine. Verder zijn er geen inhoudelijke veranderingen; spelfouten en al zijn letterlijk overgenomen.