### PR TITLE
make /blog and /events default to current year

### DIFF
--- a/layouts/blogs.erb
+++ b/layouts/blogs.erb
@@ -6,7 +6,8 @@
       </p>
       <ul class="menu-list">
         <% academic_years_blog_items.each do |year, item| %>
-        <% if @item_rep && @item_rep.path == item.path %>
+        <% if @item_rep && @item_rep.path == item.path ||
+             (!is_anything_selected(academic_years_blog_items + tag_blog_items, @item_rep) && year == @config[:academic_year]) %>
         <li>
           <a href="#" class="is-active">
             <%= pretty_year(year) %>

--- a/layouts/events.erb
+++ b/layouts/events.erb
@@ -6,7 +6,8 @@
       </p>
       <ul class="menu-list">
         <% academic_years_event_items.each do |year, item| %>
-        <% if @item_rep && @item_rep.path == item.path %>
+        <% if @item_rep && @item_rep.path == item.path ||
+            (!is_anything_selected(academic_years_event_items + tag_event_items, @item_rep) && year == @config[:academic_year]) %>
         <li>
           <a href="#" class="is-active">
             <%= pretty_year(year) %>

--- a/lib/helpers/archives.rb
+++ b/lib/helpers/archives.rb
@@ -28,6 +28,11 @@ module ArchiveHelper
     "'#{year[0]} - '#{year[1]}"
   end
 
+  def is_anything_selected(things, item)
+    things.any? { |_, thing| thing.path == item.path}
+  end
+
+
   def posts_in_year(y)
     items.find_all("/blog/#{y}/*").sort_by { |x| x[:created_at] }.reverse
   end

--- a/lib/helpers/events.rb
+++ b/lib/helpers/events.rb
@@ -58,7 +58,7 @@ module EventsHelper
   end
 
   def academic_years_event_items
-    items.find_all('/events/*').reject { |e| e[:academic_year].nil? }.map { |e| [e[:academic_year], e] }.sort_by(&:first).reverse
+    items.find_all('/events/*').reject { |e| e[:academic_year].nil? }.uniq { |p| p[:academic_year] }.map { |e| [e[:academic_year], e] }.sort_by(&:first).reverse
   end
 
   def grouped_events

--- a/lib/helpers/preprocess.rb
+++ b/lib/helpers/preprocess.rb
@@ -82,6 +82,12 @@ module PreprocessHelper
       navigable: true,
       order: 10
     )
+
+    @items.create(
+      '',
+      { academic_year: @config[:academic_year], title: type, is_yearly: true },
+      "/#{type.downcase}/index.html"
+    )
   end
 
   def create_tagly_items(type)


### PR DESCRIPTION
Makes navigating blind (without interacting with browser) easier by adding `zeus.gent/events/` and `zeus.gent/blog/` pages default to current year events and blog.

Redirects didn't work but this seems fine to me.