### PR TITLE
feat(ci): add caching for the output folder generated by nandoc

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,6 +31,14 @@ jobs:
         with:
           key: nix-${{ hashFiles('packages.nix') }}
           nix_file: 'packages.nix'
+      - name: Cache Output
+        id: cache-output
+        uses: actions/cache@v3
+        with:
+          path: ./output
+          key: build-${{ github.ref_name }}
+          restore-keys: |
+            build-master
       - name: Set environment variable
         run: "export LANG=en_US.UTF-8"
       - name: Build site

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           key: nix-${{ hashFiles('packages.nix') }}
           nix_file: 'packages.nix'
+      - name: Cache Output
+        id: cache-output
+        uses: actions/cache@v3
+        with:
+          path: output
+          key: build-${{ github.ref_name }}
+          restore-keys: |
+            build-master
       - name: Set environment variable
         run: "export LANG=en_US.UTF-8"
       - name: Build site


### PR DESCRIPTION
should make the new builds faster in CI.
It uses the cache from master when building for the first time for a PR