### PR TITLE
Set link canonical property to zeus.ugent.be

### DIFF
--- a/layouts/default.erb
+++ b/layouts/default.erb
@@ -23,7 +23,10 @@
 
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
-
+    
+    <!-- Make sure search engines only cache one deployment of this site -->
+    <link rel="canonical" href="<%= "#{@config[:base_url]}#{@item.path}" %>" />
+    
     <!-- Fathom - simple website analytics - https://github.com/usefathom/fathom -->
     <script>
     (function(f, a, t, h, o, m){


### PR DESCRIPTION
Context from the nanoc issue (https://github.com/nanoc/nanoc/issues/1642)

> At Zeus WPI (:wave:  @denisdefreyne), we run our site on multiple domains: both on zeus.ugent.be and zeus.gent. We also have `<number>`.pr.zeus.gent, which deploys previews of pull requests against the site repository. When searching content on for example Google, both zeus.gent and zeus.ugent.be show up, diluting search results. A (standardized) way to prevent duplicate content is [the canonical link element](https://en.wikipedia.org/wiki/Canonical_link_element).