### PR TITLE
Remove auto hyphens from body

### DIFF
--- a/content/assets/stylesheets/main.scss
+++ b/content/assets/stylesheets/main.scss
@@ -11,8 +11,6 @@
 
 // Sticky footer
 body {
-  hyphens: auto;
-
   &.site {
     overflow-x: hidden;
 


### PR DESCRIPTION
As an example:

old:
![image](https://github.com/ZeusWPI/zeus.ugent.be/assets/10746993/dd1cfd30-118f-4d4c-9ba0-99314f876355)

new:
![image](https://github.com/ZeusWPI/zeus.ugent.be/assets/10746993/b1981fed-b9ed-4ef1-9734-7f42abd36cc5)

I haven't found a place where the hyphen behavior is desired; but even if somewhere on the site this is wanted, we could add it with a narrower scope than 'the entire body'