### PR TITLE
Add english version of responsible disclosure policy

### DIFF
--- a/content/well-known/security.txt
+++ b/content/well-known/security.txt
@@ -1,3 +1,4 @@
 Contact: mailto:admin@zeus.ugent.be
 Preferred-Languages: nl,en
 Policy: https://git.zeus.gent/ZeusWPI/drive/raw/branch/master/varia/responsible_disclosure_policy_nl.md
+Policy: https://git.zeus.gent/ZeusWPI/drive/raw/branch/master/varia/responsible_disclosure_policy_en.md


### PR DESCRIPTION
According to https://www.rfc-editor.org/rfc/rfc9116#name-policy, the Policy field can appear multiple times (see for example "Preferred-Languages" where it is explicitly mentioned it must only appear once)

Depends on https://git.zeus.gent/ZeusWPI/drive/pulls/146/files to be merged