### PR TITLE
Update blokmap tile to fit the current form of the frontage

### DIFF
--- a/layouts/tiles/blokmap.erb
+++ b/layouts/tiles/blokmap.erb
@@ -1,4 +1,4 @@
-<div class="tile is-parent is-12">
+<div class="cell is-col-span-2">
   <a href="http://blok.ugent.be" id="blokmap-tile" class="tile is-child box has-content-centered">
       <div class="content is-large has-text-centered">
         <h1>


### PR DESCRIPTION
This makes it fullwidth again.

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/1660c13f-e6ba-4639-97e3-28c9e3fda7d1" />
