### PR TITLE
Make ical UID more consistent

### DIFF
--- a/lib/helpers/ical.rb
+++ b/lib/helpers/ical.rb
@@ -19,6 +19,7 @@ module IcalHelper
     e.description = "#{item[:description]}\n\n#{item.reps[:text].compiled_content}"
     e.location = item[:location]
     e.url = @config[:base_url] + item.path
+    e.uid = item.path.sub(/^\/events\//, '').chomp('/').tr('/', '-') + '@zeus.gent'
 
     e
   end


### PR DESCRIPTION
Some calendar applications are dumb and only identify events by UID.
This causes some sync solutions to add more events instead replacing the existing ones
These UIDs were not persistent across builds of the site.