### PR TITLE
Change blokmap tile to be more responsive

### DIFF
--- a/content/assets/stylesheets/includes/tiles.scss
+++ b/content/assets/stylesheets/includes/tiles.scss
@@ -136,16 +136,12 @@ $top_coder_size: 80px;
     background-color: rgba(0, 0, 0, 0.2);
   }
 
-  .content {
-    position: relative;
+  h1, h2, h3 {
+    color: white;
+  }
 
-    h1, h2, h3 {
-      color: white;
-    }
-
-    h2 {
-      margin-top: 0;
-    }
+  h2 {
+    margin-top: 0;
   }
 }
 

--- a/layouts/tiles/blokmap.erb
+++ b/layouts/tiles/blokmap.erb
@@ -1,6 +1,6 @@
 <div class="cell is-col-span-2">
   <a href="http://blok.ugent.be" id="blokmap-tile" class="tile is-child box has-content-centered">
-      <div class="content is-large has-text-centered">
+      <div class="is-large has-text-centered">
         <h1 class='title is-1-responsive'>
           <b>Zoek de beste plek om te blokken!</b>
         </h1>

--- a/layouts/tiles/blokmap.erb
+++ b/layouts/tiles/blokmap.erb
@@ -1,10 +1,10 @@
 <div class="cell is-col-span-2">
   <a href="http://blok.ugent.be" id="blokmap-tile" class="tile is-child box has-content-centered">
       <div class="content is-large has-text-centered">
-        <h1>
+        <h1 class='title is-1-responsive'>
           <b>Zoek de beste plek om te blokken!</b>
         </h1>
-        <h2>
+        <h2 class='title is-2-responsive'>
           blok.ugent.be
         </h2>
       </div>


### PR DESCRIPTION
On mobile, blokmap tile looks pretty bad, this should change that

Example:

<img width="554" alt="image" src="https://github.com/user-attachments/assets/7a9dd6a6-6683-4351-a11f-5387e0fd188e" />
