### PR TITLE
zapp button in header

### DIFF
--- a/layouts/partials/_navbar.erb
+++ b/layouts/partials/_navbar.erb
@@ -1,7 +1,7 @@
 <head>
-  <script type="module" src="http://localhost:3001/zapp-components/zapp-components.esm.js"></script>
-  <script nomodule src="http://localhost:3001/zapp-components/zapp-components.js"></script>
-  <link rel="stylesheet" href="http://localhost:3001/zapp-components/assets/global.css">
+  <script type="module" src="https://zapp.zeus.gent/zapp-components/zapp-components.esm.js"></script>
+  <script nomodule src="https://zapp.zeus.gent/zapp-components/zapp-components.js"></script>
+  <link rel="stylesheet" href="https://zapp.zeus.gent/zapp-components/assets/global.css">
 </head>
 
 <div id="navbar">

--- a/layouts/partials/_navbar.erb
+++ b/layouts/partials/_navbar.erb
@@ -1,3 +1,9 @@
+<head>
+  <script type="module" src="http://localhost:3001/zapp-components/zapp-components.esm.js"></script>
+  <script nomodule src="http://localhost:3001/zapp-components/zapp-components.js"></script>
+  <link rel="stylesheet" href="http://localhost:3001/zapp-components/assets/global.css">
+</head>
+
 <div id="navbar">
   <div class="navbar <%= 'is-transparent' if defined? @transparent_nav %>">
     <div class="navbar-brand">
@@ -46,6 +52,10 @@
             Schrijf je in!
           </a>
         <%end%>
+
+        <div style="width: 2.8rem; aspect-ratio: 1/1; display: flex; justify-content: center; align-items: center;">
+          <zapp-v01></zapp-v01>
+        </div>
       </div>
       <!-- TODO: Remove this is-hidden-touch, it's just a convenience for now -->
       <div class="navbar-end is-hidden-touch">

--- a/layouts/partials/_navbar.erb
+++ b/layouts/partials/_navbar.erb
@@ -53,9 +53,7 @@
           </a>
         <%end%>
 
-        <div style="width: 2.8rem; aspect-ratio: 1/1; display: flex; justify-content: center; align-items: center;">
-          <zapp-v01></zapp-v01>
-        </div>
+        
       </div>
       <!-- TODO: Remove this is-hidden-touch, it's just a convenience for now -->
       <div class="navbar-end is-hidden-touch">
@@ -84,6 +82,9 @@
             <%= fa :calendar %>
           </span>
         </a>
+      </div>
+      <div style="width: 2.8rem; aspect-ratio: 1/1; display: flex; justify-content: center; align-items: center;">
+        <zapp-v01></zapp-v01>
       </div>
     </div>
   </div>


### PR DESCRIPTION
URL where it's loaded from is localhost for now, until the new subdomain is running

<img width="1708" height="1422" alt="image" src="https://github.com/user-attachments/assets/d9beff05-6fc6-4060-af97-d7fb3eda066e" />
