### PR TITLE
Event page info

### DIFF
--- a/layouts/events.erb
+++ b/layouts/events.erb
@@ -53,7 +53,9 @@
         <div class="card-content">
           <p>Alle events zijn toegankelijk voor alle jaren, behalve als het anders staat vermeld. </p>
           <p>Er zullen ook altijd Zeus-leden aanwezig zijn die kunnen helpen als je iets niet begrijpt. 🙂</p>
-          <button class="button is-primary" onclick="window.location.href='/ical.ics'">Zet events in je persoonlijke kalender</button>
+          <a href="/ical.ics" class="button is-primary">
+            Zet events in je persoonlijke kalender
+          </a>
         </div>
       </div>
       <h1>Upcoming events</h1>


### PR DESCRIPTION
Add a info card in the events tab that contains text about accessibility to events and an easier button to put events in personal calendar